### PR TITLE
fix: correct main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"author": "DTStack Corporation",
 	"license": "MIT",
 	"main": "out/esm/main.js",
-	"module": "out/esm/monaco.contribution.js",
+	"module": "out/esm/main.d.ts",
 	"types": "out/esm/main.d.ts",
 	"files": [
 		"out"


### PR DESCRIPTION
## 简介
关联 issue #33 
目前的 package.json 中  main 字段设置为 `out/esm/monaco.contribution.js`，这会导致如果项目使用的是 esm 规范， 在直接从 monaco-sql-langugae 中导入时，node 解析的路径为 `out/esm/monaco.contribution.js`，进而导致打包失败。