### PR TITLE
fix: correct diag position

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -130,9 +130,9 @@ function toDiagnostics(resource: Uri, diag: any): editor.IMarkerData {
 	return {
 		severity: toSeverity(diag.severity),
 		startLineNumber: diag.startLine,
-		startColumn: diag.startCol,
+		startColumn: diag.startCol + 1,
 		endLineNumber: diag.endLine,
-		endColumn: diag.endCol,
+		endColumn: diag.endCol + 1,
 		message: diag.message,
 		code: code,
 		source: diag.source


### PR DESCRIPTION
## 简介
修复飘红位置不准确的问题 #43 

## 主要变更
将 ParserError 转换成 Diagnostics 时，`startCol`  和 `endCol`  各向右偏移一个字符位置