### PR TITLE
feat: add vscode plus colorTheme

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ export * from './setupLanguageMode';
 export * from './workerManager';
 export * from './common/utils';
 export * from './common/constants';
+export * from './theme';
 
 export { SyntaxContextType } from 'dt-sql-parser';
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,3 @@
+import vsPlusTheme from './vs-plus';
+
+export { vsPlusTheme };

--- a/src/theme/vs-plus/dark.ts
+++ b/src/theme/vs-plus/dark.ts
@@ -1,0 +1,38 @@
+import { TokenClassConsts, postfixTokenClass } from '../../common/constants';
+import { editor } from '../../fillers/monaco-editor-core';
+
+/**
+ * Inspired by VS Code ColorTheme Default Dark+.
+ */
+export const darkThemeData: editor.IStandaloneThemeData = {
+	base: 'vs-dark',
+	inherit: true,
+	rules: [
+		{ token: postfixTokenClass(TokenClassConsts.BINARY), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.BINARY_ESCAPE), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT), foreground: '6a9955' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT_QUOTE), foreground: '6a9955' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER), foreground: 'd4d4d4' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_CURLY), foreground: 'da70d6' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_PAREN), foreground: 'ffd700' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_SQUARE), foreground: 'ffd700' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER), foreground: '9cdcfe' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER_QUOTE), foreground: '9cdcfe' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD), foreground: '569cd6' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD_SCOPE), foreground: 'c586c0' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_FLOAT), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_BINARY), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_OCTAL), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_HEX), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR), foreground: 'd4d4d4' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_KEYWORD), foreground: '569cd6' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_SYMBOL), foreground: 'd4d4d4' },
+		{ token: postfixTokenClass(TokenClassConsts.PREDEFINED), foreground: 'dcdcaa' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING), foreground: 'ce9178' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING_ESCAPE), foreground: 'ce9178' },
+		{ token: postfixTokenClass(TokenClassConsts.TYPE), foreground: '4ec9b0' },
+		{ token: postfixTokenClass(TokenClassConsts.VARIABLE), foreground: '4fc1ff' }
+	],
+	colors: {}
+};

--- a/src/theme/vs-plus/hc-black.ts
+++ b/src/theme/vs-plus/hc-black.ts
@@ -1,0 +1,38 @@
+import { TokenClassConsts, postfixTokenClass } from '../../common/constants';
+import { editor } from '../../fillers/monaco-editor-core';
+
+/**
+ * Inspired by VS Code ColorTheme Dark High Contrast.
+ */
+export const hcBlackThemeData: editor.IStandaloneThemeData = {
+	base: 'hc-black',
+	inherit: true,
+	rules: [
+		{ token: postfixTokenClass(TokenClassConsts.BINARY), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.BINARY_ESCAPE), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT), foreground: '7ca668' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT_QUOTE), foreground: '7ca668' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER), foreground: 'ffffff' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_CURLY), foreground: 'da70d6' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_PAREN), foreground: 'ffd700' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_SQUARE), foreground: 'ffd700' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER), foreground: '9cdcfe' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER_QUOTE), foreground: '9cdcfe' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD), foreground: '569cd6' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD_SCOPE), foreground: 'c586c0' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_FLOAT), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_BINARY), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_OCTAL), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_HEX), foreground: 'b5cea8' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR), foreground: 'ffffff' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_KEYWORD), foreground: '569cd6' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_SYMBOL), foreground: 'ffffff' },
+		{ token: postfixTokenClass(TokenClassConsts.PREDEFINED), foreground: 'dcdcaa' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING), foreground: 'ce9178' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING_ESCAPE), foreground: 'ce9178' },
+		{ token: postfixTokenClass(TokenClassConsts.TYPE), foreground: '4ec9b0' },
+		{ token: postfixTokenClass(TokenClassConsts.VARIABLE), foreground: '4fc1ff' }
+	],
+	colors: {}
+};

--- a/src/theme/vs-plus/index.ts
+++ b/src/theme/vs-plus/index.ts
@@ -1,0 +1,11 @@
+import { lightThemeData } from './light';
+import { darkThemeData } from './dark';
+import { hcBlackThemeData } from './hc-black';
+
+const vsPlusTheme = {
+	lightThemeData,
+	darkThemeData,
+	hcBlackThemeData
+};
+
+export default vsPlusTheme;

--- a/src/theme/vs-plus/light.ts
+++ b/src/theme/vs-plus/light.ts
@@ -1,0 +1,38 @@
+import { TokenClassConsts, postfixTokenClass } from '../../common/constants';
+import { editor } from '../../fillers/monaco-editor-core';
+
+/**
+ * Inspired by VS Code ColorTheme Default Light+.
+ */
+export const lightThemeData: editor.IStandaloneThemeData = {
+	base: 'vs',
+	inherit: true,
+	rules: [
+		{ token: postfixTokenClass(TokenClassConsts.BINARY), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.BINARY_ESCAPE), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT), foreground: '008000' },
+		{ token: postfixTokenClass(TokenClassConsts.COMMENT_QUOTE), foreground: '008000' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER), foreground: '000000' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_CURLY), foreground: '319331' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_PAREN), foreground: '0431fa' },
+		{ token: postfixTokenClass(TokenClassConsts.DELIMITER_SQUARE), foreground: '0431fa' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER), foreground: '001080' },
+		{ token: postfixTokenClass(TokenClassConsts.IDENTIFIER_QUOTE), foreground: '001080' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD), foreground: '0000ff' },
+		{ token: postfixTokenClass(TokenClassConsts.KEYWORD_SCOPE), foreground: 'af00db' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_FLOAT), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_BINARY), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_OCTAL), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.NUMBER_HEX), foreground: '098658' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR), foreground: '000000' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_KEYWORD), foreground: '0000ff' },
+		{ token: postfixTokenClass(TokenClassConsts.OPERATOR_SYMBOL), foreground: '000000' },
+		{ token: postfixTokenClass(TokenClassConsts.PREDEFINED), foreground: '795e26' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING), foreground: 'a31515' },
+		{ token: postfixTokenClass(TokenClassConsts.STRING_ESCAPE), foreground: 'a31515' },
+		{ token: postfixTokenClass(TokenClassConsts.TYPE), foreground: '267f99' },
+		{ token: postfixTokenClass(TokenClassConsts.VARIABLE), foreground: '4fc1ff' }
+	],
+	colors: {}
+};


### PR DESCRIPTION
## 主要变更
添加 vscode plus 主题 #57 ， 包括
1. vs-dark+
2. vs-light+
3. hc-black