### PR TITLE
feat: prevent multiple registrations of feature adapters

### DIFF
--- a/src/hivesql/hivesql.contribution.ts
+++ b/src/hivesql/hivesql.contribution.ts
@@ -13,9 +13,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'hivesql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerHiveSQLLanguage(
 	completionService?: CompletionService,
@@ -40,6 +43,10 @@ export function registerHiveSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }

--- a/src/sparksql/sparksql.contribution.ts
+++ b/src/sparksql/sparksql.contribution.ts
@@ -13,9 +13,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'sparksql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerSparkSQLLanguage(
 	completionService?: CompletionService,
@@ -40,6 +43,10 @@ export function registerSparkSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }

--- a/src/trinosql/trinosql.contribution.ts
+++ b/src/trinosql/trinosql.contribution.ts
@@ -8,9 +8,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'trinosql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerTrinoSQLLanguage(
 	completionService?: CompletionService,
@@ -35,6 +38,10 @@ export function registerTrinoSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }


### PR DESCRIPTION
## 主要变更
1. 在注册高亮、自动补全等功能之前，先 dispose 掉已存在的功能

## Why
目前如果多次调用 registerLanguage 方法，会导致高亮和自动补全功能也注册多次，这样会导致不必要的性能损耗。