### PR TITLE
Feat/decouple config

### DIFF
--- a/src/_.contribution.ts
+++ b/src/_.contribution.ts
@@ -141,24 +141,6 @@ export interface ModeConfiguration {
 	readonly selectionRanges?: boolean;
 }
 
-/**
- * Currently, only diagnostics and completionItems are supported.
- * All features will be supported in the future,
- * and following interface will be removed and replaced with ModeConfiguration.
- */
-export type SupportedModeConfiguration = {
-	/**
-	 * Defines whether the built-in completionItemProvider is enabled.
-	 * Defaults to true
-	 */
-	readonly completionItems?: boolean;
-	/**
-	 * Defines whether the built-in diagnostic provider is enabled.
-	 * Defaults to true
-	 */
-	readonly diagnostics?: boolean;
-};
-
 export interface DiagnosticsOptions {
 	readonly validate?: boolean;
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -29,13 +29,13 @@ export const TokenClassConsts = {
 
 export const postfixTokenClass = (token: string) => token + '.sql';
 
-export const LanguageIdConsts = {
-	FLINK: 'flinksql',
-	HIVE: 'hivesql',
-	MySQL: 'mysql',
-	PG: 'pgsql',
-	PL: 'plsql',
-	SPARK: 'sparksql',
-	SQL: 'sql',
-	TRINO: 'trinosql'
-};
+export enum LanguageIdEnum {
+	FLINK = 'flinksql',
+	HIVE = 'hivesql',
+	MYSQL = 'mysql',
+	PG = 'pgsql',
+	PL = 'plsql',
+	SPARK = 'sparksql',
+	SQL = 'sql',
+	TRINO = 'trinosql'
+}

--- a/src/flinksql/flinksql.contribution.ts
+++ b/src/flinksql/flinksql.contribution.ts
@@ -3,50 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	CompletionService,
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage,
-	SupportedModeConfiguration
-} from '../_.contribution';
-import { languages, IDisposable } from '../fillers/monaco-editor-core';
-
-const languageId = 'flinksql';
-let disposables: IDisposable = {
-	dispose() {}
-};
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
 registerLanguage({
-	id: languageId,
+	id: LanguageIdEnum.FLINK,
 	extensions: ['.flinksql'],
 	aliases: ['FlinkSQL', 'flink', 'Flink'],
 	loader: () => import('./flinksql')
 });
 
-loadLanguage(languageId);
+loadLanguage(LanguageIdEnum.FLINK);
 
-export function registerFlinkSQLLanguage(
-	completionService?: CompletionService,
-	options?: SupportedModeConfiguration
-) {
-	const modeConfiguration = typeof options === 'object' ? options : {};
-
-	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-		languageId,
-		diagnosticDefault,
-		{ ...modeConfigurationDefault, ...modeConfiguration },
-		completionService
-	);
-
-	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => {
-			disposables.dispose();
-			disposables = mode.setupLanguageMode(defaults);
-			return disposables;
-		});
-	});
-}
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.FLINK,
+	completionItems: true,
+	diagnostics: true
+});

--- a/src/hivesql/hivesql.contribution.ts
+++ b/src/hivesql/hivesql.contribution.ts
@@ -3,50 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	CompletionService,
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage,
-	SupportedModeConfiguration
-} from '../_.contribution';
-import { languages, IDisposable } from '../fillers/monaco-editor-core';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
-const languageId = 'hivesql';
-let disposables: IDisposable = {
-	dispose() {}
-};
+registerLanguage({
+	id: LanguageIdEnum.HIVE,
+	extensions: ['.hivesql'],
+	aliases: ['HiveSQL', 'hive', 'Hive'],
+	loader: () => import('./hivesql')
+});
 
-export function registerHiveSQLLanguage(
-	completionService?: CompletionService,
-	options?: SupportedModeConfiguration
-) {
-	registerLanguage({
-		id: languageId,
-		extensions: ['.hivesql'],
-		aliases: ['HiveSQL', 'hive', 'Hive'],
-		loader: () => import('./hivesql')
-	});
+loadLanguage(LanguageIdEnum.HIVE);
 
-	loadLanguage(languageId);
-
-	const modeConfiguration = typeof options === 'object' ? options : {};
-
-	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-		languageId,
-		diagnosticDefault,
-		{ ...modeConfigurationDefault, ...modeConfiguration },
-		completionService
-	);
-
-	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => {
-			disposables.dispose();
-			disposables = mode.setupLanguageMode(defaults);
-			return disposables;
-		});
-	});
-}
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.HIVE,
+	completionItems: true,
+	diagnostics: true
+});

--- a/src/hivesql/hivesql.contribution.ts
+++ b/src/hivesql/hivesql.contribution.ts
@@ -13,9 +13,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'hivesql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerHiveSQLLanguage(
 	completionService?: CompletionService,
@@ -40,6 +43,10 @@ export function registerHiveSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }

--- a/src/hivesql/hivesql.test.ts
+++ b/src/hivesql/hivesql.test.ts
@@ -4,10 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { testTokenization } from '../test/testRunner';
-import { registerHiveSQLLanguage } from './hivesql.contribution';
 import { TokenClassConsts, postfixTokenClass } from '../common/constants';
-
-registerHiveSQLLanguage();
 
 testTokenization('hivesql', [
 	// Comments

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -155,7 +155,7 @@ export class CompletionAdapter<T extends IWorker> implements languages.Completio
 		position: Position,
 		context: languages.CompletionContext,
 		token: CancellationToken
-	): Promise<languages.CompletionList | undefined> {
+	): Promise<languages.CompletionList> {
 		const resource = model.uri;
 		return this._worker(resource)
 			.then((worker) => {
@@ -214,7 +214,7 @@ const defaultCompletionService: CompletionService = function (
 	const keywordsCompletionItems: ICompletionItem[] = keywords.map((kw) => ({
 		label: kw,
 		kind: languages.CompletionItemKind.Keyword,
-		detail: '关键字'
+		detail: 'keyword'
 	}));
 
 	return Promise.resolve(keywordsCompletionItems);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,8 @@
-export { registerFlinkSQLLanguage } from './flinksql/flinksql.contribution';
-export { registerSparkSQLLanguage } from './sparksql/sparksql.contribution';
-export { registerHiveSQLLanguage } from './hivesql/hivesql.contribution';
-export { registerTrinoSQLLanguage } from './trinosql/trinosql.contribution';
-
 export * from './_.contribution';
 export * from './languageService';
 export * from './languageFeatures';
 export * from './setupLanguageMode';
+export * from './setupLanguageFeatures';
 export * from './workerManager';
 export * from './common/utils';
 export * from './common/constants';

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,14 +1,8 @@
+import './flinksql/flinksql.contribution';
+import './sparksql/sparksql.contribution';
+import './hivesql/hivesql.contribution';
+import './trinosql/trinosql.contribution';
 import './sql/sql.contribution';
 import './mysql/mysql.contribution';
 import './plsql/plsql.contribution';
 import './pgsql/pgsql.contribution';
-
-import { registerFlinkSQLLanguage } from './flinksql/flinksql.contribution';
-import { registerSparkSQLLanguage } from './sparksql/sparksql.contribution';
-import { registerHiveSQLLanguage } from './hivesql/hivesql.contribution';
-import { registerTrinoSQLLanguage } from './trinosql/trinosql.contribution';
-
-registerFlinkSQLLanguage();
-registerSparkSQLLanguage();
-registerHiveSQLLanguage();
-registerTrinoSQLLanguage();

--- a/src/mysql/mysql.contribution.ts
+++ b/src/mysql/mysql.contribution.ts
@@ -3,33 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage
-} from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
-
-const languageId = 'mysql';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
 registerLanguage({
-	id: languageId,
+	id: LanguageIdEnum.MYSQL,
 	extensions: [],
 	aliases: ['MySQL'],
 	loader: () => import('./mysql')
 });
 
-loadLanguage(languageId);
+loadLanguage(LanguageIdEnum.MYSQL);
 
-const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-	languageId,
-	diagnosticDefault,
-	modeConfigurationDefault
-);
-
-languages.onLanguage(languageId, () => {
-	import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.MYSQL,
+	completionItems: false,
+	diagnostics: true
 });

--- a/src/pgsql/pgsql.contribution.ts
+++ b/src/pgsql/pgsql.contribution.ts
@@ -3,33 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage
-} from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
-
-const languageId = 'pgsql';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
 registerLanguage({
-	id: languageId,
+	id: LanguageIdEnum.PG,
 	extensions: [],
 	aliases: ['PgSQL', 'postgresql', 'PostgreSQL'],
 	loader: () => import('./pgsql')
 });
 
-loadLanguage(languageId);
+loadLanguage(LanguageIdEnum.PG);
 
-const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-	languageId,
-	diagnosticDefault,
-	modeConfigurationDefault
-);
-
-languages.onLanguage(languageId, () => {
-	import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.PG,
+	completionItems: false,
+	diagnostics: true
 });

--- a/src/plsql/plsql.contribution.ts
+++ b/src/plsql/plsql.contribution.ts
@@ -3,33 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage
-} from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
-
-const languageId = 'plsql';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
 registerLanguage({
-	id: languageId,
-	extensions: ['.sql'],
+	id: LanguageIdEnum.PL,
+	extensions: [],
 	aliases: ['PLSQL'],
 	loader: () => import('./plsql')
 });
 
-loadLanguage(languageId);
+loadLanguage(LanguageIdEnum.PL);
 
-const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-	languageId,
-	diagnosticDefault,
-	modeConfigurationDefault
-);
-
-languages.onLanguage(languageId, () => {
-	import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.PL,
+	completionItems: false,
+	diagnostics: true
 });

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -6,7 +6,7 @@ import {
 	modeConfigurationDefault
 } from './_.contribution';
 import { languages, IDisposable } from './fillers/monaco-editor-core';
-import { LanguageIdEnum } from './main';
+import { LanguageIdEnum } from './common/constants';
 
 type LanguageId = `${LanguageIdEnum}`;
 

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -1,0 +1,94 @@
+import {
+	CompletionService,
+	diagnosticDefault,
+	LanguageServiceDefaults,
+	LanguageServiceDefaultsImpl,
+	modeConfigurationDefault
+} from './_.contribution';
+import { languages, IDisposable } from './fillers/monaco-editor-core';
+import { LanguageIdEnum } from './main';
+
+type LanguageId = `${LanguageIdEnum}`;
+
+export interface FeatureConfiguration {
+	languageId: LanguageId;
+	/**
+	 * Defines whether the built-in completionItemProvider is enabled.
+	 * Defaults to true.
+	 */
+	completionItems?: boolean;
+	/**
+	 * Defines whether the built-in diagnostic provider is enabled.
+	 * Defaults to true.
+	 */
+	diagnostics?: boolean;
+	/**
+	 * Define a service to customize  completionItems.
+	 * By default, only keyword autocomplete items are included.
+	 */
+	completionService?: CompletionService;
+}
+
+const disposableMap = new Map<LanguageId, IDisposable>();
+const featureLoadedMap = new Map<LanguageId, boolean>();
+const configurationMap = new Map<LanguageId, FeatureConfiguration>();
+
+export function setupLanguageFeatures(configuration: FeatureConfiguration) {
+	if (typeof configuration !== 'object') {
+		return;
+	}
+
+	const { languageId, completionService, ...rest } = processConfiguration(configuration);
+
+	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
+		languageId,
+		diagnosticDefault,
+		Object.assign({}, modeConfigurationDefault, rest),
+		completionService
+	);
+
+	function setup() {
+		import('./setupLanguageMode').then((mode) => {
+			if (disposableMap.has(languageId)) {
+				disposableMap.get(languageId)?.dispose();
+			}
+			const disposable = mode.setupLanguageMode(defaults);
+			disposableMap.set(languageId, disposable);
+			return disposable;
+		});
+	}
+
+	if (featureLoadedMap.get(languageId)) {
+		setup();
+	} else {
+		languages.onLanguage(languageId, () => {
+			setup();
+			featureLoadedMap.set(languageId, true);
+		});
+	}
+}
+
+function processConfiguration(configuration: FeatureConfiguration) {
+	let finalConfiguration = Object.assign({}, configuration);
+
+	const languageId = configuration.languageId;
+	const currentConfiguration = configurationMap.get(languageId);
+
+	if (currentConfiguration) {
+		finalConfiguration = Object.assign({}, currentConfiguration, finalConfiguration);
+	}
+
+	if (
+		// The following languages are not support codeCompletion now.
+		[LanguageIdEnum.MYSQL, LanguageIdEnum.PG, LanguageIdEnum.PL, LanguageIdEnum.SQL].includes(
+			languageId as LanguageIdEnum
+		)
+	) {
+		finalConfiguration.completionItems = false;
+	}
+
+	// save current configurationMap
+	configurationMap.set(languageId, finalConfiguration);
+
+	return finalConfiguration;
+}

--- a/src/sparksql/sparksql.contribution.ts
+++ b/src/sparksql/sparksql.contribution.ts
@@ -13,9 +13,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'sparksql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerSparkSQLLanguage(
 	completionService?: CompletionService,
@@ -40,6 +43,10 @@ export function registerSparkSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }

--- a/src/sparksql/sparksql.contribution.ts
+++ b/src/sparksql/sparksql.contribution.ts
@@ -3,50 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-	CompletionService,
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage,
-	SupportedModeConfiguration
-} from '../_.contribution';
-import { languages, IDisposable } from '../fillers/monaco-editor-core';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
-const languageId = 'sparksql';
-let disposables: IDisposable = {
-	dispose() {}
-};
+registerLanguage({
+	id: LanguageIdEnum.SPARK,
+	extensions: ['.sparksql'],
+	aliases: ['SparkSQL', 'spark', 'Spark'],
+	loader: () => import('./sparksql')
+});
 
-export function registerSparkSQLLanguage(
-	completionService?: CompletionService,
-	options?: SupportedModeConfiguration
-) {
-	registerLanguage({
-		id: languageId,
-		extensions: ['.sparksql'],
-		aliases: ['SparkSQL', 'spark', 'Spark'],
-		loader: () => import('./sparksql')
-	});
+loadLanguage(LanguageIdEnum.SPARK);
 
-	loadLanguage(languageId);
-
-	const modeConfiguration = typeof options === 'object' ? options : {};
-
-	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-		languageId,
-		diagnosticDefault,
-		{ ...modeConfigurationDefault, ...modeConfiguration },
-		completionService
-	);
-
-	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => {
-			disposables.dispose();
-			disposables = mode.setupLanguageMode(defaults);
-			return disposables;
-		});
-	});
-}
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.SPARK,
+	completionItems: true,
+	diagnostics: true
+});

--- a/src/sql/sql.contribution.ts
+++ b/src/sql/sql.contribution.ts
@@ -2,33 +2,22 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage
-} from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
 
-const languageId = 'sql';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
 registerLanguage({
-	id: languageId,
+	id: LanguageIdEnum.SQL,
 	extensions: ['.sql'],
 	aliases: ['SQL'],
 	loader: () => import('./sql')
 });
 
-loadLanguage(languageId);
+loadLanguage(LanguageIdEnum.SQL);
 
-const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-	languageId,
-	diagnosticDefault,
-	modeConfigurationDefault
-);
-
-languages.onLanguage(languageId, () => {
-	import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.SQL,
+	completionItems: false,
+	diagnostics: true
 });

--- a/src/trinosql/trinosql.contribution.ts
+++ b/src/trinosql/trinosql.contribution.ts
@@ -8,9 +8,12 @@ import {
 	registerLanguage,
 	SupportedModeConfiguration
 } from '../_.contribution';
-import { languages } from '../fillers/monaco-editor-core';
+import { languages, IDisposable } from '../fillers/monaco-editor-core';
 
 const languageId = 'trinosql';
+let disposables: IDisposable = {
+	dispose() {}
+};
 
 export function registerTrinoSQLLanguage(
 	completionService?: CompletionService,
@@ -35,6 +38,10 @@ export function registerTrinoSQLLanguage(
 	);
 
 	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => mode.setupLanguageMode(defaults));
+		import('../setupLanguageMode').then((mode) => {
+			disposables.dispose();
+			disposables = mode.setupLanguageMode(defaults);
+			return disposables;
+		});
 	});
 }

--- a/src/trinosql/trinosql.contribution.ts
+++ b/src/trinosql/trinosql.contribution.ts
@@ -1,47 +1,18 @@
-import {
-	CompletionService,
-	diagnosticDefault,
-	LanguageServiceDefaults,
-	LanguageServiceDefaultsImpl,
-	loadLanguage,
-	modeConfigurationDefault,
-	registerLanguage,
-	SupportedModeConfiguration
-} from '../_.contribution';
-import { languages, IDisposable } from '../fillers/monaco-editor-core';
+import { loadLanguage, registerLanguage } from '../_.contribution';
+import { setupLanguageFeatures } from '../setupLanguageFeatures';
+import { LanguageIdEnum } from '../common/constants';
 
-const languageId = 'trinosql';
-let disposables: IDisposable = {
-	dispose() {}
-};
+registerLanguage({
+	id: LanguageIdEnum.TRINO,
+	extensions: [],
+	aliases: ['TrinoSQL', 'trino', 'Trino', 'prestosql', 'PrestoSQL', 'presto', 'Presto'],
+	loader: () => import('./trinosql')
+});
 
-export function registerTrinoSQLLanguage(
-	completionService?: CompletionService,
-	options?: SupportedModeConfiguration
-) {
-	registerLanguage({
-		id: languageId,
-		extensions: [],
-		aliases: ['TrinoSQL', 'trino', 'Trino', 'prestosql', 'PrestoSQL', 'presto', 'Presto'],
-		loader: () => import('./trinosql')
-	});
+loadLanguage(LanguageIdEnum.TRINO);
 
-	loadLanguage(languageId);
-
-	const modeConfiguration = typeof options === 'object' ? options : {};
-
-	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
-		languageId,
-		diagnosticDefault,
-		{ ...modeConfigurationDefault, ...modeConfiguration },
-		completionService
-	);
-
-	languages.onLanguage(languageId, () => {
-		import('../setupLanguageMode').then((mode) => {
-			disposables.dispose();
-			disposables = mode.setupLanguageMode(defaults);
-			return disposables;
-		});
-	});
-}
+setupLanguageFeatures({
+	languageId: LanguageIdEnum.TRINO,
+	completionItems: true,
+	diagnostics: true
+});


### PR DESCRIPTION
## 主要变更
1. 在注册/设置飘红、自动补全等功能之前，先 dispose 掉已存在的功能， 目前如果多次调用 registerLanguage 方法，会导致高亮和自动补全功能也注册多次，这样会导致不必要的性能损耗。
2. 将 language 的注册逻辑与 language 功能设置逻辑解耦
3. 在 language 对应的 contribution 文件中，默认注册飘红以及自动补全功能。
4. 导出 `setupLanguageFeatures` 方法，用于修改language的功能配置，比如说动态关闭或打开自动补全功能
5. 移除 registerxxxLanguage 方法，因为它不是一个好的设计
6. 项目内统一使用 LanguageIdEnum，而不是以字符串字面量的形式