### PR TITLE
bugfix(pgsql): delete pgsql's limit in processConfiguration function

### DIFF
--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -80,9 +80,7 @@ function processConfiguration(configuration: FeatureConfiguration) {
 
 	if (
 		// The following languages are not support codeCompletion now.
-		[LanguageIdEnum.PG, LanguageIdEnum.PL, LanguageIdEnum.SQL].includes(
-			languageId as LanguageIdEnum
-		)
+		[LanguageIdEnum.PL, LanguageIdEnum.SQL].includes(languageId as LanguageIdEnum)
 	) {
 		finalConfiguration.completionItems = false;
 	}


### PR DESCRIPTION
- delete pgsql's limit in processConfiguration function

  去掉不支持自动补全sql语言限制中的pgsql。