### PR TITLE
feat: optimize ICompletionItem type and add ICompletionList type

### DIFF
--- a/src/_.contribution.ts
+++ b/src/_.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { languages, Emitter, IEvent, editor, Position } from './fillers/monaco-editor-core';
+import { languages, Emitter, IEvent, editor, Position, IRange } from './fillers/monaco-editor-core';
 import { Suggestions } from 'dt-sql-parser';
 
 interface ILang extends languages.ILanguageExtensionPoint {
@@ -146,12 +146,21 @@ export interface DiagnosticsOptions {
 }
 
 /**
- * A completion item, it will be convert to monaco.languages.CompletionItem.
+ * A completion item.
+ * ICompletionItem is pretty much the same as {@link languages.CompletionItem},
+ * with the only difference being that the range and insertText is optional.
  */
-export interface ICompletionItem extends Partial<languages.CompletionItem> {
-	label: string | languages.CompletionItemLabel;
-	kind: languages.CompletionItemKind;
-	detail: string;
+export interface ICompletionItem extends Omit<languages.CompletionItem, 'range' | 'insertText'> {
+	range?: IRange | languages.CompletionItemRanges;
+	insertText?: string;
+}
+
+/**
+ * ICompletionList is pretty much the same as {@link languages.CompletionList},
+ * with the only difference being that the type of suggestion is {@link ICompletionItem}
+ */
+export interface ICompletionList extends Omit<languages.CompletionList, 'suggestions'> {
+	suggestions: ICompletionItem[];
 }
 
 /**
@@ -166,7 +175,7 @@ export type CompletionService = (
 	position: Position,
 	completionContext: languages.CompletionContext,
 	suggestions: Suggestions | null
-) => Promise<ICompletionItem[] | { completionItems: ICompletionItem[], incomplete: boolean }>;
+) => Promise<ICompletionItem[] | ICompletionList>;
 
 export interface LanguageServiceDefaults {
 	readonly languageId: string;

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -170,20 +170,25 @@ export class CompletionAdapter<T extends IWorker> implements languages.Completio
 					position.lineNumber,
 					wordInfo.endColumn
 				);
-				const unwrappedCompletions = Array.isArray(completions) ? completions : completions.completionItems
-				const completionItems: languages.CompletionItem[] = unwrappedCompletions.map((item) => ({
-					...item,
-					insertText:
-						item.insertText ??
-						(typeof item.label === 'string' ? item.label : item.label.label),
-					range: item.range ?? wordRange,
-					insertTextRules:
-						item.insertTextRules ??
-						languages.CompletionItemInsertTextRule.InsertAsSnippet
-				}));
+				const unwrappedCompletions = Array.isArray(completions)
+					? completions
+					: completions.suggestions;
+				const completionItems: languages.CompletionItem[] = unwrappedCompletions.map(
+					(item) => ({
+						...item,
+						insertText:
+							item.insertText ??
+							(typeof item.label === 'string' ? item.label : item.label.label),
+						range: item.range ?? wordRange,
+						insertTextRules:
+							item.insertTextRules ??
+							languages.CompletionItemInsertTextRule.InsertAsSnippet
+					})
+				);
 
 				return {
 					suggestions: completionItems,
+					dispose: Array.isArray(completions) ? undefined : completions.dispose,
 					incomplete: Array.isArray(completions) ? undefined : completions.incomplete
 				};
 			});


### PR DESCRIPTION
##  简介
优化自动补全相关接口 #99 

## 主要变更
1. 重新定义 `ICompletionItem` 接口，这个接口与 monaco 内置的 `CompletionItem` 几乎完全相同，区别是 `ICompletionItem` 的 `range` 和 `insertText` 是可选的，因为 Monaco SQL Lanuages 在内部处理了这两个烦人的属性
2. 新增 `ICompletionList` 接口，这个接口与 monaco 内置的 `CompletionList` 几乎相同，区别是`ICompletionList` 的 `suggestions` 属性的类型为 `ICompletionItem[]`
3. `compeltionService` 返回值的类型同步变更

## Why
在 PR #100  中支持了自动补全功能返回值中的 `incomplete` 属性，这是一个很好的PR。

这个PR 也从侧面说明自动补全的相关逻辑可能封装的痕迹过重，我希望 `competetionService` 的返回值尽量与 monaco 内置的 `provideCompletionItems` 返回值类型保持一致，这可以降低 Monaco SQL Languages 的上手成本。

另外在此之前，`ICompletionItem` 接口的 `detail` 成员被设置为必填，但实际上这是不必要的