### PR TITLE
feat: support custom params

### DIFF
--- a/src/_.contribution.ts
+++ b/src/_.contribution.ts
@@ -178,12 +178,19 @@ export type CompletionService = (
 	entities: EntityContext[] | null
 ) => Promise<ICompletionItem[] | ICompletionList>;
 
+/**
+ * A function to preprocess code.
+ * @param code editor value
+ */
+export type PreprocessCode = (code: string) => string;
+
 export interface LanguageServiceDefaults {
 	readonly languageId: string;
 	readonly onDidChange: IEvent<LanguageServiceDefaults>;
 	readonly diagnosticsOptions: DiagnosticsOptions;
 	readonly modeConfiguration: ModeConfiguration;
 	readonly completionService?: CompletionService;
+	readonly preprocessCode?: PreprocessCode;
 	setDiagnosticsOptions(options: DiagnosticsOptions): void;
 	setModeConfiguration(modeConfiguration: ModeConfiguration): void;
 }
@@ -194,17 +201,20 @@ export class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 	private _modeConfiguration!: ModeConfiguration;
 	private _languageId: string;
 	private _completionService?: CompletionService;
+	private _preprocessCode?: PreprocessCode;
 
 	constructor(
 		languageId: string,
 		diagnosticsOptions: DiagnosticsOptions,
 		modeConfiguration: ModeConfiguration,
-		completionService?: CompletionService
+		completionService?: CompletionService,
+		preprocessCode?: PreprocessCode
 	) {
 		this._languageId = languageId;
 		this.setDiagnosticsOptions(diagnosticsOptions);
 		this.setModeConfiguration(modeConfiguration);
 		this._completionService = completionService;
+		this._preprocessCode = preprocessCode;
 	}
 
 	get onDidChange(): IEvent<LanguageServiceDefaults> {
@@ -225,6 +235,10 @@ export class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 
 	get completionService(): CompletionService | undefined {
 		return this._completionService;
+	}
+
+	get preprocessCode(): PreprocessCode | undefined {
+		return this._preprocessCode;
 	}
 
 	setDiagnosticsOptions(options: DiagnosticsOptions): void {

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -1,6 +1,7 @@
 import {
 	CompletionService,
 	diagnosticDefault,
+	PreprocessCode,
 	LanguageServiceDefaults,
 	LanguageServiceDefaultsImpl,
 	modeConfigurationDefault
@@ -27,6 +28,11 @@ export interface FeatureConfiguration {
 	 * By default, only keyword autocomplete items are included.
 	 */
 	completionService?: CompletionService;
+	/**
+	 * Define a function to preprocess code.
+	 * By default, do not something.
+	 */
+	preprocessCode?: PreprocessCode;
 }
 
 const disposableMap = new Map<LanguageId, IDisposable>();
@@ -38,13 +44,15 @@ export function setupLanguageFeatures(configuration: FeatureConfiguration) {
 		return;
 	}
 
-	const { languageId, completionService, ...rest } = processConfiguration(configuration);
+	const { languageId, completionService, preprocessCode, ...rest } =
+		processConfiguration(configuration);
 
 	const defaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
 		languageId,
 		diagnosticDefault,
 		Object.assign({}, modeConfigurationDefault, rest),
-		completionService
+		completionService,
+		preprocessCode
 	);
 
 	function setup() {

--- a/website/src/languages/index.ts
+++ b/website/src/languages/index.ts
@@ -5,38 +5,100 @@ import { setupLanguageFeatures, LanguageIdEnum } from 'monaco-sql-languages/out/
 
 import { completionService } from './helpers/completionService';
 
+/**
+ * replace dtstack custom params, eg: @@{componentParams}, ${taskCustomParams}
+ * @param code editor value
+ * @returns replaced string
+ */
+const preprocessCode = (code: string): string => {
+	const regex1 = /@@{[A-Za-z0-9._-]*}/g;
+	const regex2 = /\${[A-Za-z0-9._-]*}/g;
+	let result = code;
+
+	if (regex1.test(code)) {
+		result = result.replace(regex1, (str) => {
+			return str.replace(/@|{|}|\.|-/g, '_');
+		});
+	}
+	if (regex2.test(code)) {
+		result = result.replace(regex2, (str) => {
+			return str.replace(/\$|{|}|\.|-/g, '_');
+		});
+	}
+	return result;
+};
+
+/**
+ * replace dtstack custom grammar, eg: @@{componentParams}, ${taskCustomParams}
+ * @param code editor value
+ * @param mark some sql grammar need special mark to replace the beginning and the end
+ * @returns replaced string
+ */
+const preprocessCodeHive = (code: string, mark?: string): string => {
+	const regex1 = /@@{[A-Za-z0-9._-]*}/g;
+	const regex2 = /\${[A-Za-z0-9._-]*}/g;
+	let result = code;
+
+	if (regex1.test(code)) {
+		result = result.replace(regex1, (str) => {
+			if (mark) {
+				return str
+					.replace(/@/, mark)
+					.replace(/}/, mark)
+					.replace(/@|{|\.|-/g, '_');
+			}
+			return str.replace(/@|{|}|\.|-/g, '_');
+		});
+	}
+	if (regex2.test(code)) {
+		result = result.replace(regex2, (str) => {
+			if (mark) {
+				return str.replace(/\$|}/g, mark).replace(/{|\.|-/g, '_');
+			}
+			return str.replace(/\$|{|}|\.|-/g, '_');
+		});
+	}
+	return result;
+};
+
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.FLINK,
-	completionService
+	completionService,
+	preprocessCode
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.SPARK,
-	completionService
+	completionService,
+	preprocessCode
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.HIVE,
-	completionService
+	completionService,
+	preprocessCode: (code: string) => preprocessCodeHive(code, '`')
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.MYSQL,
-	completionService
+	completionService,
+	preprocessCode
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.TRINO,
-	completionService
+	completionService,
+	preprocessCode
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.PG,
-	completionService
+	completionService,
+	preprocessCode
 });
 
 setupLanguageFeatures({
 	languageId: LanguageIdEnum.IMPALA,
-	completionService
+	completionService,
+	preprocessCode
 });
-


### PR DESCRIPTION
1. `setupLanguageFeatures` 方法支持传入 `preprocessCode` 参数，用于预处理代码  
2.  `website` 中使用 `preprocessCode` 参数，处理离线业务场景中的自定义参数语法  
3. 在语法检查和自动补全中使用了 `preprocessCode` 方法


![Jietu20240205-144139-HD](https://github.com/DTStack/monaco-sql-languages/assets/34759874/31b2a242-adc8-462c-a87f-6925e4be13ad)


预览地址：https://liuxy0551.github.io/monaco-sql-languages/
测试的 SQL：
``` sql
SELECT ${aaad} from ${aaad};

SELECT @@{dddd} from ${aaa};

SELECT @@{dddd} from @@{dddd};

SELECT @@{dddd} from @@{dd.a.d_a.c-d} where @@{} = 1;
```