### PR TITLE
docs: integrate-esm url

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -60,7 +60,7 @@ npm install monaco-sql-languages
 
 ## 集成
 
-- [集成 Monaco SQL Languages 的 ESM 版本](./documents/intgrate-esm.zh-CN.md)
+- [集成 Monaco SQL Languages 的 ESM 版本](./documents/integrate-esm.zh-CN.md)
 - [Monaco SQL Languages 集成问题修复](./documents/problem-solving.zh-CN.md)
 
 <br/>


### PR DESCRIPTION
问题：中文文档中的 集成 Monaco SQL Languages 的 ESM 版本 链接拼写少了一个 e  
预览：https://github.com/liuxy0551/monaco-sql-languages/blob/fix_readme_url/README-zh_CN.md#%E9%9B%86%E6%88%90