### PR TITLE
feat: add reference and definition provider

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -1,16 +1,22 @@
-import {
-	editor,
-	Uri,
-	IDisposable,
-	MarkerSeverity,
-	Range,
-	languages,
-	Position,
-	CancellationToken
-} from './fillers/monaco-editor-core';
-import { debounce } from './common/utils';
-import { BaseSQLWorker } from './baseSQLWorker';
 import type { ParseError } from 'dt-sql-parser';
+import {
+	EntityContext,
+} from 'dt-sql-parser/dist/parser/common/entityCollector';
+import { WordPosition } from 'dt-sql-parser/dist/parser/common/textAndWord';
+import * as monaco from 'monaco-editor';
+
+import { BaseSQLWorker } from './baseSQLWorker';
+import { debounce } from './common/utils';
+import {
+	CancellationToken,
+	editor,
+	IDisposable,
+	languages,
+	MarkerSeverity,
+	Position,
+	Range,
+	Uri,
+} from './fillers/monaco-editor-core';
 import type { LanguageServiceDefaults } from './monaco.contribution';
 
 export interface WorkerAccessor<T extends BaseSQLWorker> {
@@ -194,6 +200,104 @@ export class CompletionAdapter<T extends BaseSQLWorker>
 					dispose: Array.isArray(completions) ? undefined : completions.dispose,
 					incomplete: Array.isArray(completions) ? undefined : completions.incomplete
 				};
+			});
+	}
+}
+
+export class DefinitionAdapter<T extends BaseSQLWorker> implements languages.DefinitionProvider {
+	constructor(
+		private readonly _worker: WorkerAccessor<T>,
+		private readonly _defaults: LanguageServiceDefaults) {}
+	provideDefinition(
+		model: editor.IReadOnlyModel,
+		position: Position,
+		_token: CancellationToken
+	): languages.ProviderResult<languages.Definition | languages.LocationLink[]> {
+		const resource = model.uri;
+		const lineContent = model.getLineContent(position.lineNumber);
+		if (lineContent.startsWith('--')) return null;
+		return this._worker(resource)
+			.then((worker) => {
+				let code = model?.getValue() || '';
+				if (typeof this._defaults.preprocessCode === 'function') {
+					code = this._defaults.preprocessCode(code);
+				}
+				return worker.getAllEntities(code);
+			})
+			.then((entities) => {
+				const word = model.getWordAtPosition(position);
+				let pos: WordPosition = {
+					line: -1,
+					startIndex: -1,
+					endIndex: -1,
+					startColumn: -1,
+					endColumn: -1
+				};
+				entities?.forEach((entity: EntityContext) => {
+					if (
+						entity.entityContextType.includes('Create') &&
+						word?.word &&
+						entity.text === word?.word
+					) {
+						pos = entity.position;
+					}
+				});
+				if (pos && pos.line !== -1) {
+					return {
+						uri: model.uri,
+						range: new monaco.Range(
+							pos?.line,
+							pos?.startColumn,
+							pos?.line,
+							pos?.endColumn
+						)
+					};
+				}
+			});
+	}
+}
+
+export class ReferenceAdapter<T extends BaseSQLWorker> implements languages.ReferenceProvider {
+	constructor(
+		private readonly _worker: WorkerAccessor<T>,
+		private readonly _defaults: LanguageServiceDefaults
+	) {}
+	provideReferences(
+		model: editor.IReadOnlyModel,
+		position: Position,
+		_context: languages.ReferenceContext,
+		_token: CancellationToken
+	): languages.ProviderResult<languages.Location[]> {
+		const resource = model.uri;
+		const lineContent = model.getLineContent(position.lineNumber);
+		if (!lineContent.startsWith('CREATE')) return;
+		return this._worker(resource)
+			.then((worker) => {
+				let code = model?.getValue() || '';
+				if (typeof this._defaults.preprocessCode === 'function') {
+					code = this._defaults.preprocessCode(code);
+				}
+				return worker.getAllEntities(model?.getValue());
+			})
+			.then((entities) => {
+				const word = model.getWordAtPosition(position);
+				const arr: languages.Location[] = [];
+				entities?.forEach((entity) => {
+					if (word?.word && entity.text === word?.word) {
+						let pos: WordPosition | null = null;
+						pos = entity.position;
+						arr.push({
+							uri: model.uri,
+							range: new monaco.Range(
+								pos?.line,
+								pos?.startColumn,
+								pos?.line,
+								pos?.endColumn
+							)
+						});
+					}
+				});
+				return arr;
 			});
 	}
 }

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -1,7 +1,5 @@
 import type { ParseError } from 'dt-sql-parser';
-import {
-	EntityContext,
-} from 'dt-sql-parser/dist/parser/common/entityCollector';
+import { EntityContext } from 'dt-sql-parser/dist/parser/common/entityCollector';
 import { WordPosition } from 'dt-sql-parser/dist/parser/common/textAndWord';
 import * as monaco from 'monaco-editor';
 
@@ -15,7 +13,7 @@ import {
 	MarkerSeverity,
 	Position,
 	Range,
-	Uri,
+	Uri
 } from './fillers/monaco-editor-core';
 import type { LanguageServiceDefaults } from './monaco.contribution';
 
@@ -207,7 +205,8 @@ export class CompletionAdapter<T extends BaseSQLWorker>
 export class DefinitionAdapter<T extends BaseSQLWorker> implements languages.DefinitionProvider {
 	constructor(
 		private readonly _worker: WorkerAccessor<T>,
-		private readonly _defaults: LanguageServiceDefaults) {}
+		private readonly _defaults: LanguageServiceDefaults
+	) {}
 	provideDefinition(
 		model: editor.IReadOnlyModel,
 		position: Position,

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -1,7 +1,5 @@
 import type { ParseError } from 'dt-sql-parser';
-import {
-	EntityContext,
-} from 'dt-sql-parser/dist/parser/common/entityCollector';
+import { EntityContext } from 'dt-sql-parser/dist/parser/common/entityCollector';
 import { WordPosition } from 'dt-sql-parser/dist/parser/common/textAndWord';
 import * as monaco from 'monaco-editor';
 
@@ -15,7 +13,7 @@ import {
 	MarkerSeverity,
 	Position,
 	Range,
-	Uri,
+	Uri
 } from './fillers/monaco-editor-core';
 import type { LanguageServiceDefaults } from './monaco.contribution';
 
@@ -236,13 +234,17 @@ export class DefinitionAdapter<T extends BaseSQLWorker> implements languages.Def
 				};
 				const curEntity = entities?.find((entity: EntityContext) => {
 					const entityPosition = entity.position;
-					if (entityPosition.startColumn === word?.startColumn && entityPosition.endColumn === word?.endColumn && entityPosition.line === position.lineNumber) {
+					if (
+						entityPosition.startColumn === word?.startColumn &&
+						entityPosition.endColumn === word?.endColumn &&
+						entityPosition.line === position.lineNumber
+					) {
 						return entity;
 					}
 					return null;
-				})
+				});
 				if (curEntity) {
-					for(let k in entities) {
+					for (let k in entities) {
 						const entity = entities[Number(k)];
 						if (
 							entity.entityContextType.includes('Create') &&
@@ -297,14 +299,22 @@ export class ReferenceAdapter<T extends BaseSQLWorker> implements languages.Refe
 				const arr: languages.Location[] = [];
 				const curEntity = entities?.find((entity: EntityContext) => {
 					const entityPosition = entity.position;
-					if (entityPosition.startColumn === word?.startColumn && entityPosition.endColumn === word?.endColumn && entityPosition.line === position.lineNumber) {
+					if (
+						entityPosition.startColumn === word?.startColumn &&
+						entityPosition.endColumn === word?.endColumn &&
+						entityPosition.line === position.lineNumber
+					) {
 						return entity;
 					}
 					return null;
-				})
+				});
 				if (curEntity) {
 					entities?.forEach((entity) => {
-						if (word?.word && entity.text === word?.word && curEntity.entityContextType.includes(entity.entityContextType)) {
+						if (
+							word?.word &&
+							entity.text === word?.word &&
+							curEntity.entityContextType.includes(entity.entityContextType)
+						) {
 							let pos: WordPosition | null = null;
 							pos = entity.position;
 							arr.push({
@@ -318,7 +328,6 @@ export class ReferenceAdapter<T extends BaseSQLWorker> implements languages.Refe
 							});
 						}
 					});
-
 				}
 				return arr;
 			});

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -201,12 +201,17 @@ export class CompletionAdapter<T extends BaseSQLWorker>
 			});
 	}
 }
-
+/**
+ * The adapter is for the definition of the symbol at the given position and document.
+ **/
 export class DefinitionAdapter<T extends BaseSQLWorker> implements languages.DefinitionProvider {
 	constructor(
 		private readonly _worker: WorkerAccessor<T>,
 		private readonly _defaults: LanguageServiceDefaults
 	) {}
+	/**
+	 * Provide the definition of the symbol at the given position and document.
+	 **/
 	provideDefinition(
 		model: editor.IReadOnlyModel,
 		position: Position,
@@ -271,12 +276,17 @@ export class DefinitionAdapter<T extends BaseSQLWorker> implements languages.Def
 			});
 	}
 }
-
+/**
+ * The adapter is for the references of the symbol at the given position and document.
+ **/
 export class ReferenceAdapter<T extends BaseSQLWorker> implements languages.ReferenceProvider {
 	constructor(
 		private readonly _worker: WorkerAccessor<T>,
 		private readonly _defaults: LanguageServiceDefaults
 	) {}
+	/**
+	 * Provide a set of project-wide references for the given position and document.
+	 **/
 	provideReferences(
 		model: editor.IReadOnlyModel,
 		position: Position,

--- a/src/languages/flink/flink.contribution.ts
+++ b/src/languages/flink/flink.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.FLINK,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.FLINK, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/flink/flink.contribution.ts
+++ b/src/languages/flink/flink.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.FLINK, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/hive/hive.contribution.ts
+++ b/src/languages/hive/hive.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.HIVE, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/hive/hive.contribution.ts
+++ b/src/languages/hive/hive.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.HIVE,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.HIVE, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/impala/impala.contribution.ts
+++ b/src/languages/impala/impala.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.IMPALA,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.IMPALA, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/impala/impala.contribution.ts
+++ b/src/languages/impala/impala.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.IMPALA, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/mysql/mysql.contribution.ts
+++ b/src/languages/mysql/mysql.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.MYSQL, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/mysql/mysql.contribution.ts
+++ b/src/languages/mysql/mysql.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.MYSQL,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.MYSQL, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/pgsql/pgsql.contribution.ts
+++ b/src/languages/pgsql/pgsql.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.PG, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/pgsql/pgsql.contribution.ts
+++ b/src/languages/pgsql/pgsql.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.PG,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.PG, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/spark/spark.contribution.ts
+++ b/src/languages/spark/spark.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.SPARK,
@@ -16,5 +16,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.SPARK, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/languages/spark/spark.contribution.ts
+++ b/src/languages/spark/spark.contribution.ts
@@ -18,5 +18,5 @@ setupLanguageFeatures(LanguageIdEnum.SPARK, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/trino/trino.contribution.ts
+++ b/src/languages/trino/trino.contribution.ts
@@ -13,5 +13,5 @@ setupLanguageFeatures(LanguageIdEnum.TRINO, {
 	completionItems: true,
 	diagnostics: true,
 	references: true,
-	definitions: true,
+	definitions: true
 });

--- a/src/languages/trino/trino.contribution.ts
+++ b/src/languages/trino/trino.contribution.ts
@@ -1,6 +1,6 @@
 import { registerLanguage } from '../../_.contribution';
-import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
 
 registerLanguage({
 	id: LanguageIdEnum.TRINO,
@@ -11,5 +11,7 @@ registerLanguage({
 
 setupLanguageFeatures(LanguageIdEnum.TRINO, {
 	completionItems: true,
-	diagnostics: true
+	diagnostics: true,
+	references: true,
+	definitions: true,
 });

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,16 +1,6 @@
-import {
-	EntityContext,
-	Suggestions,
-} from 'dt-sql-parser';
+import { EntityContext, Suggestions } from 'dt-sql-parser';
 
-import {
-	editor,
-	Emitter,
-	IEvent,
-	IRange,
-	languages,
-	Position,
-} from './fillers/monaco-editor-core';
+import { editor, Emitter, IEvent, IRange, languages, Position } from './fillers/monaco-editor-core';
 
 /**
  * A completion item.

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,5 +1,16 @@
-import { languages, Emitter, IEvent, editor, Position, IRange } from './fillers/monaco-editor-core';
-import { EntityContext, Suggestions } from 'dt-sql-parser';
+import {
+	EntityContext,
+	Suggestions,
+} from 'dt-sql-parser';
+
+import {
+	editor,
+	Emitter,
+	IEvent,
+	IRange,
+	languages,
+	Position,
+} from './fillers/monaco-editor-core';
 
 /**
  * A completion item.
@@ -65,7 +76,7 @@ export interface ModeConfiguration {
 	/**
 	 * Defines whether the built-in definitions provider is enabled.
 	 */
-	// readonly definitions?: boolean;
+	readonly definitions?: boolean;
 
 	/**
 	 * Defines whether the built-in rename provider is enabled.
@@ -75,7 +86,7 @@ export interface ModeConfiguration {
 	/**
 	 * Defines whether the built-in references provider is enabled.
 	 */
-	// readonly references?: boolean;
+	readonly references?: boolean;
 }
 
 /**
@@ -171,5 +182,7 @@ export const modeConfigurationDefault: Required<ModeConfiguration> = {
 		completionService: defaultCompletionService,
 		triggerCharacters: ['.', ' ']
 	},
-	diagnostics: true
+	diagnostics: true,
+	definitions: true,
+	references: true
 };

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -1,13 +1,16 @@
+import { LanguageIdEnum } from './common/constants';
 import {
-	PreprocessCode,
+	IDisposable,
+	languages,
+} from './fillers/monaco-editor-core';
+import {
+	CompletionOptions,
 	LanguageServiceDefaults,
 	LanguageServiceDefaultsImpl,
-	modeConfigurationDefault,
 	ModeConfiguration,
-	CompletionOptions
+	modeConfigurationDefault,
+	PreprocessCode,
 } from './monaco.contribution';
-import { languages, IDisposable } from './fillers/monaco-editor-core';
-import { LanguageIdEnum } from './common/constants';
 
 export interface FeatureConfiguration {
 	/**
@@ -20,6 +23,14 @@ export interface FeatureConfiguration {
 	 * Defaults to true.
 	 */
 	diagnostics?: boolean;
+	/**
+	 * Defines whether the built-in definitions provider is enabled.
+	 */
+	definitions?: boolean;
+	/**
+	 * Defines whether the built-in references provider is enabled.
+	 */
+	references?: boolean;
 	/**
 	 * Define a function to preprocess code.
 	 * By default, do not something.
@@ -110,6 +121,14 @@ function processConfiguration(
 			? configuration.completionItems!.triggerCharacters
 			: (defaults?.modeConfiguration.completionItems.triggerCharacters ??
 				modeConfigurationDefault.completionItems.triggerCharacters);
+	const references =
+				typeof configuration.references === 'boolean'
+					? configuration.references
+					: (defaults?.modeConfiguration.references ?? modeConfigurationDefault.references);
+	const definitions =
+					typeof configuration.definitions === 'boolean'
+						? configuration.definitions
+						: (defaults?.modeConfiguration.definitions ?? modeConfigurationDefault.definitions);
 
 	return {
 		diagnostics,
@@ -117,6 +136,8 @@ function processConfiguration(
 			enable: completionEnable,
 			completionService,
 			triggerCharacters
-		}
+		},
+		references,
+		definitions,
 	};
 }

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -1,15 +1,12 @@
 import { LanguageIdEnum } from './common/constants';
-import {
-	IDisposable,
-	languages,
-} from './fillers/monaco-editor-core';
+import { IDisposable, languages } from './fillers/monaco-editor-core';
 import {
 	CompletionOptions,
 	LanguageServiceDefaults,
 	LanguageServiceDefaultsImpl,
 	ModeConfiguration,
 	modeConfigurationDefault,
-	PreprocessCode,
+	PreprocessCode
 } from './monaco.contribution';
 
 export interface FeatureConfiguration {
@@ -122,13 +119,13 @@ function processConfiguration(
 			: (defaults?.modeConfiguration.completionItems.triggerCharacters ??
 				modeConfigurationDefault.completionItems.triggerCharacters);
 	const references =
-				typeof configuration.references === 'boolean'
-					? configuration.references
-					: (defaults?.modeConfiguration.references ?? modeConfigurationDefault.references);
+		typeof configuration.references === 'boolean'
+			? configuration.references
+			: (defaults?.modeConfiguration.references ?? modeConfigurationDefault.references);
 	const definitions =
-					typeof configuration.definitions === 'boolean'
-						? configuration.definitions
-						: (defaults?.modeConfiguration.definitions ?? modeConfigurationDefault.definitions);
+		typeof configuration.definitions === 'boolean'
+			? configuration.definitions
+			: (defaults?.modeConfiguration.definitions ?? modeConfigurationDefault.definitions);
 
 	return {
 		diagnostics,
@@ -138,6 +135,6 @@ function processConfiguration(
 			triggerCharacters
 		},
 		references,
-		definitions,
+		definitions
 	};
 }

--- a/src/setupLanguageMode.ts
+++ b/src/setupLanguageMode.ts
@@ -1,8 +1,12 @@
-import { WorkerManager } from './workerManager';
-import { LanguageServiceDefaults } from './monaco.contribution';
-import * as languageFeatures from './languageFeatures';
-import { Uri, IDisposable, languages } from './fillers/monaco-editor-core';
 import type { BaseSQLWorker } from './baseSQLWorker';
+import {
+	IDisposable,
+	languages,
+	Uri,
+} from './fillers/monaco-editor-core';
+import * as languageFeatures from './languageFeatures';
+import { LanguageServiceDefaults } from './monaco.contribution';
+import { WorkerManager } from './workerManager';
 
 export function setupLanguageMode<T extends BaseSQLWorker>(
 	defaults: LanguageServiceDefaults
@@ -19,7 +23,6 @@ export function setupLanguageMode<T extends BaseSQLWorker>(
 
 	function registerProviders(): void {
 		const { languageId, modeConfiguration } = defaults;
-
 		disposeAll(providers);
 
 		if (modeConfiguration.diagnostics) {
@@ -31,6 +34,24 @@ export function setupLanguageMode<T extends BaseSQLWorker>(
 				languages.registerCompletionItemProvider(
 					languageId,
 					new languageFeatures.CompletionAdapter(worker, defaults)
+				)
+			);
+		}
+
+		if (modeConfiguration.references) {
+			providers.push(
+				languages.registerReferenceProvider(
+					languageId,
+					new languageFeatures.ReferenceAdapter(worker, defaults)
+				)
+			);
+		}
+
+		if (modeConfiguration.definitions) {
+			providers.push(
+				languages.registerDefinitionProvider(
+					languageId,
+					new languageFeatures.DefinitionAdapter(worker, defaults)
 				)
 			);
 		}

--- a/src/setupLanguageMode.ts
+++ b/src/setupLanguageMode.ts
@@ -1,9 +1,5 @@
 import type { BaseSQLWorker } from './baseSQLWorker';
-import {
-	IDisposable,
-	languages,
-	Uri,
-} from './fillers/monaco-editor-core';
+import { IDisposable, languages, Uri } from './fillers/monaco-editor-core';
 import * as languageFeatures from './languageFeatures';
 import { LanguageServiceDefaults } from './monaco.contribution';
 import { WorkerManager } from './workerManager';


### PR DESCRIPTION
## feat
支持 https://github.com/DTStack/monaco-sql-languages/issues/162 跳转到定义、跳转到引用位置功能
- 支持跳转到引用、跳转到定义
- 支持外部控制跳转到引用、跳转到定义配置的开关，如下图所示：
<img width="784" alt="image" src="https://github.com/user-attachments/assets/aec2e469-86ca-4391-a579-d00c8a843ef8">


### 需要注意
- 跳转到引用的默认快捷键是`Shift+F12`，但由于大家的使用习惯是`Command+click`，所以需要关注下

当你在 Monaco Editor 中配置 references 为 true 而 definitions 为 false 时，Command + Click (或 Ctrl + Click) 无法跳转到引用，这是因为 Monaco Editor 的默认行为是：Command + Click 主要用于跳转到 定义 (definitions)，而不是引用 (references)。 即使你启用了 references 功能，Command + Click 仍然优先处理 DefinitionProvider，因为它被设计为跳转到定义的快捷方式。

ReferenceProvider 提供的是“查找所有引用”的功能，这通常通过右键菜单或自定义命令来触发，而不是 Command + Click。 Command + Click 的行为是由 Monaco Editor 的核心功能决定的，它与 ReferenceProvider 和 DefinitionProvider 的启用状态之间没有直接的逻辑关联。 Command + Click 始终优先尝试跳转到定义，只有当 DefinitionProvider 无法提供定义时，它才可能尝试其他行为。

常规使用跳转到定义、引用功能时，我们都是配套打开的，此时，我们通过Command + Click 可以进行跳转到定义和引用。通常不会只打开跳转到引用，而不打开跳转到定义。如果只打开跳转到引用，而不打开跳转到定义，那么我们通过 右键唤起菜单跳到引用，通过选择某一个具体引用进行跳转，这个操作也是流畅且合理的。

## 预览
![iShot_2024-12-02_18 01 39](https://github.com/user-attachments/assets/43e5c2f6-5318-4a04-adee-39e485a0a55d)


## 预览地址
https://cythia828.github.io/monaco-sql-languages/

