### PR TITLE
fix: deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"watch-esm": "tsc -p ./tsconfig.esm.json --watch",
 		"test": "npm run build-amd && mocha ./test/all.js",
 		"dev": "node --max_old_space_size=4092 & cd website && npm run dev",
-		"prod": "rm -rf ./docs && node --max_old_space_size=4092 & cd website && npm run build",
+		"prod": "npm run build && rm -rf ./docs && node --max_old_space_size=4092 & cd website && npm run build",
 		"deploy": "npm run prod && gh-pages -d docs -r git@github.com:DTStack/monaco-sql-languages.git",
 		"format": "prettier --write .",
 		"prettier-check": "prettier --check .",

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -59,6 +59,7 @@ function execStandardVersion(res) {
 		.then(({ message }) => {
 			console.log('Please checkout recent commit, and then');
 			console.log('Push branch and new tag to github, publish package to npm');
+			console.log('Please run "npm run deploy" to deploy website to github pages.');
 			// message && console.log(message)
 		})
 		.catch(({ error, code }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ export * from './monaco.contribution';
 export * from './languageService';
 export * from './setupLanguageFeatures';
 export * from './common/constants';
+export * from './common/utils';
 export * from './theme';
 
 export { EntityContextType, StmtContextType } from 'dt-sql-parser';

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ export * from './monaco.contribution';
 export * from './languageService';
 export * from './setupLanguageFeatures';
 export * from './common/constants';
-export * from './common/utils';
 export * from './theme';
 
 export { EntityContextType, StmtContextType } from 'dt-sql-parser';

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { create, Workbench } from '@dtinsight/molecule';
 import InstanceService from '@dtinsight/molecule/esm/services/instanceService';
 import { ExtendsWorkbench } from './extensions/workbench';
+import { version, dependencies } from '../../package.json';
 
 import './languages';
 
@@ -27,5 +28,10 @@ function App(): React.ReactElement {
 
 	return <div>{MyWorkbench}</div>;
 }
+
+window.console.log(
+	`%c dt-sql-parser: v${dependencies['dt-sql-parser']} \n monaco-sql-languages: v${version}`,
+	'font-family: Cabin, Helvetica, Arial, sans-serif;text-align: left;font-size:32px;color:#B21212;'
+);
 
 export default App;

--- a/website/src/extensions/workbench/sidebar.tsx
+++ b/website/src/extensions/workbench/sidebar.tsx
@@ -9,7 +9,7 @@ import { IEditorTab, IProblemsItem, MarkerSeverity } from '@dtinsight/molecule/e
 
 import { defaultLanguage, defaultEditorTab, defaultLanguageStatusItem, languages } from './common';
 import { LanguageService, ParseError } from 'monaco-sql-languages/esm/languageService';
-import { debounce } from 'monaco-sql-languages/esm/common/utils';
+import { debounce } from './utils';
 
 export default class Sidebar extends React.Component {
 	private _language = defaultLanguage;

--- a/website/src/extensions/workbench/utils.ts
+++ b/website/src/extensions/workbench/utils.ts
@@ -1,0 +1,21 @@
+export function debounce<T extends (...args: unknown[]) => unknown>(
+	func: T,
+	timeout: number,
+	immediate?: boolean
+): (...args: Parameters<T>) => unknown {
+	let timer: NodeJS.Timeout | null = null;
+	return (...args) => {
+		if (timer) {
+			clearTimeout(timer);
+		}
+		if (immediate && !timer) {
+			return func?.(...args);
+		}
+
+		timer = setTimeout(() => {
+			timer && clearTimeout(timer);
+			timer = null;
+			func?.(...args);
+		}, timeout);
+	};
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
 		}
 	},
 	base: '/monaco-sql-languages/',
+	build: {
+		commonjsOptions: {
+			transformMixedEsModules: true
+		},
+		outDir: resolve(__dirname, '../docs')
+	},
 	server: {
 		fs: {
 			allow: ['..']


### PR DESCRIPTION
- 目前发现 monaco-sql-languages playground 不是最新的内容，上次是 2024 年 1 月份部署的了，给别人验证效果产生误导，这里添加下 CD，main 分支有更新会自动部署 playground
- 发现一些 build 问题同步修复，目前先 build monaco-sql-languages，再 build website 会有 debounce 的导入的问题
- 打印了 monaco-sql-languages 和 dt-sql-parser 版本

<img width="967" alt="image" src="https://github.com/user-attachments/assets/b34e17ae-d77d-4c97-9b8d-faeec6508a1f">

在线预览（F12）：https://liuxy0551.github.io/monaco-sql-languages/