### PR TITLE
docs: correct attribute name in README

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -100,7 +100,7 @@ npm install monaco-sql-languages
         LanguageIdEnum,
         CompletionService,
         ICompletionItem,
-        SyntaxContextType
+        EntityContextType
      } from 'monaco-sql-languages';
 
     const completionService: CompletionService = function (
@@ -125,11 +125,11 @@ npm install monaco-sql-languages
             let syntaxCompletionItems: ICompletionItem[] = [];
 
             syntax.forEach((item) => {
-                if (item.syntaxContextType === SyntaxContextType.DATABASE) {
+                if (item.syntaxContextType === EntityContextType.DATABASE) {
                     const databaseCompletions: ICompletionItem[] = []; // some completions about databaseName
                     syntaxCompletionItems = [...syntaxCompletionItems, ...databaseCompletions];
                 }
-                if (item.syntaxContextType === SyntaxContextType.TABLE) {
+                if (item.syntaxContextType === EntityContextType.TABLE) {
                     const tableCompletions: ICompletionItem[] = []; // some completions about tableName
                     syntaxCompletionItems = [...syntaxCompletionItems, ...tableCompletions];
                 }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm install monaco-sql-languages
         LanguageIdEnum,
         CompletionService,
         ICompletionItem,
-        SyntaxContextType
+        EntityContextType
      } from 'monaco-sql-languages';
 
     const completionService: CompletionService = function (
@@ -125,11 +125,11 @@ npm install monaco-sql-languages
             let syntaxCompletionItems: ICompletionItem[] = [];
 
             syntax.forEach((item) => {
-                if (item.syntaxContextType === SyntaxContextType.DATABASE) {
+                if (item.syntaxContextType === EntityContextType.DATABASE) {
                     const databaseCompletions: ICompletionItem[] = []; // some completions about databaseName
                     syntaxCompletionItems = [...syntaxCompletionItems, ...databaseCompletions];
                 }
-                if (item.syntaxContextType === SyntaxContextType.TABLE) {
+                if (item.syntaxContextType === EntityContextType.TABLE) {
                     const tableCompletions: ICompletionItem[] = []; // some completions about tableName
                     syntaxCompletionItems = [...syntaxCompletionItems, ...tableCompletions];
                 }


### PR DESCRIPTION
- Corrected the exported attribute name from 'SyntaxContextType' to 'EntityContextType' in the README
- Ensures documentation is consistent with the latest API