### PR TITLE
feat: #14988 stream dataTypes and builtinFunctions highlight

### DIFF
--- a/src/languages/flink/flink.ts
+++ b/src/languages/flink/flink.ts
@@ -292,10 +292,11 @@ export const language = <languages.IMonarchLanguage>{
 		'EXP',
 		'CEIL',
 		'CEILING',
-		'FLOOR',
 		'SIN',
 		'SINH',
+		'SQRT',
 		'COS',
+		'MOD',
 		'TAN',
 		'TANH',
 		'COT',
@@ -335,6 +336,7 @@ export const language = <languages.IMonarchLanguage>{
 		'CONCAT',
 		'CONCAT_WS',
 		'LPAD',
+		'RIGHT',
 		'RPAD',
 		'FROM_BASE64',
 		'TO_BASE64',
@@ -343,6 +345,7 @@ export const language = <languages.IMonarchLanguage>{
 		'DECODE',
 		'ENCODE',
 		'INSTR',
+		'LEFT',
 		'LOCATE',
 		'PARSE_URL',
 		'REGEXP',
@@ -375,15 +378,17 @@ export const language = <languages.IMonarchLanguage>{
 		'TO_TIMESTAMP_LTZ',
 		'TO_TIMESTAMP',
 		'CURRENT_WATERMARK',
+		'OVERLAPS',
 		// Conditional Functions
 		'COALESCE',
+		'GREATEST',
 		'IF',
 		'IFNULL',
 		'IS_ALPHA',
 		'IS_DECIMAL',
 		'IS_DIGIT',
-		'GREATEST',
 		'LEAST',
+		'NULLIF',
 		// Type Conversion Functions
 		'CAST',
 		'TRY_CAST',
@@ -391,7 +396,12 @@ export const language = <languages.IMonarchLanguage>{
 		// Collection Functions
 		'CARDINALITY',
 		'ELEMENT',
+		'ARRAY',
+		'MAP',
 		'ARRAY_CONTAINS',
+		// comparison function
+		'EXISTS',
+		'IN',
 		// JSON Functions
 		'JSON_EXISTS',
 		'JSON_STRING',
@@ -404,14 +414,15 @@ export const language = <languages.IMonarchLanguage>{
 		// Grouping Functions
 		'GROUP_ID',
 		'GROUPING',
+		'GROUPING_ID',
 		// Hash Functions
 		'MD5',
 		'SHA1',
+		'SHA2',
 		'SHA224',
 		'SHA256',
 		'SHA384',
 		'SHA512',
-		'SHA2',
 		// Aggregate Functions
 		'COUNT',
 		'AVG',
@@ -459,7 +470,6 @@ export const language = <languages.IMonarchLanguage>{
 		'TIME',
 		'TIMESTAMP',
 		'TIMESTAMP_LTZ',
-		'INTERVAL',
 		'ARRAY',
 		'MULTISET',
 		'MAP',
@@ -467,6 +477,7 @@ export const language = <languages.IMonarchLanguage>{
 		'RAW',
 		'DEC',
 		'NUMERIC',
+		'INT',
 		'INTERVAL'
 	],
 	scopeKeywords: ['CASE', 'END', 'WHEN', 'THEN', 'ELSE'],
@@ -483,6 +494,7 @@ export const language = <languages.IMonarchLanguage>{
 			{ include: '@complexIdentifiers' },
 			{ include: '@scopes' },
 			{ include: '@complexDataTypes' },
+			{ include: '@complexFunctions' },
 			[/[;,.]/, TokenClassConsts.DELIMITER],
 			[/[\(\)\[\]\{\}]/, '@brackets'],
 			[
@@ -550,6 +562,10 @@ export const language = <languages.IMonarchLanguage>{
 			[/DOUBLE\s+PRECISION\b/i, { token: TokenClassConsts.TYPE }],
 			[/WITHOUT\s+TIME\s+ZONE\b/i, { token: TokenClassConsts.TYPE }],
 			[/WITH\s+LOCAL\s+TIME\s+ZONE\b/i, { token: TokenClassConsts.TYPE }]
+		],
+		complexFunctions: [
+			[/NOT\s+IN\b/i, { token: TokenClassConsts.PREDEFINED }],
+			[/IS\s+JSON\b/i, { token: TokenClassConsts.PREDEFINED }]
 		]
 	}
 };


### PR DESCRIPTION
### 改动

- 部分数据类型高亮，这次只添加了 `INT`
- 部分内置函数枚举，这里实际可以不添加，因为子产品中接口会返回，会 concat 进来，但为了防止后续由 monaco-sql-languages 实现所有函数的高亮，这里刚好排查添加上
- `NOT IN` 带空格的函数高亮（其他类型也可以）


### 自测
使用 `0.12.3-beta.4` beta 包在实时中已验证
<img width="526" alt="image" src="https://github.com/user-attachments/assets/2316ee19-3684-474f-9c12-c78b2b46aec6">
