### PR TITLE
feat: add generic SQL language support

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -39,6 +39,7 @@ Monaco SQL Languages 是一个基于 Monaco Editor 的 SQL 语言项目，从 [m
 -   Trino (Presto)
 -   PostgreSQL
 -   Impala
+-   GenericSQL
 
 <br/>
 
@@ -72,6 +73,7 @@ npm install monaco-sql-languages
     import 'monaco-sql-languages/esm/languages/trino/trino.contribution';
     import 'monaco-sql-languages/esm/languages/pgsql/pgsql.contribution';
     import 'monaco-sql-languages/esm/languages/impala/impala.contribution';
+    import 'monaco-sql-languages/esm/languages/generic/generic.contribution';
 
     // 或者你可以通过下面的方式一次性导入所有的语言功能
     // import 'monaco-sql-languages/esm/all.contributions';

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This project is based on the SQL language project of Monaco Editor, which was fo
 -   Trino (Presto)
 -   PostgreSQL
 -   Impala
+-   GenericSQL
 
 <br/>
 
@@ -71,6 +72,7 @@ npm install monaco-sql-languages
     import 'monaco-sql-languages/esm/languages/trino/trino.contribution';
     import 'monaco-sql-languages/esm/languages/pgsql/pgsql.contribution';
     import 'monaco-sql-languages/esm/languages/impala/impala.contribution';
+    import 'monaco-sql-languages/esm/languages/generic/generic.contribution';
 
     // Or you can import all language contributions at once.
     // import 'monaco-sql-languages/esm/all.contributions';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"postgresql",
 		"flink",
 		"trino",
-		"impala"
+		"impala",
+		"generic"
 	],
 	"repository": {
 		"type": "git",
@@ -84,6 +85,6 @@
 		]
 	},
 	"dependencies": {
-		"dt-sql-parser": "^4.5.0-beta.1"
+		"dt-sql-parser": "4.5.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       dt-sql-parser:
-        specifier: ^4.5.0-beta.1
-        version: 4.5.0-beta.1(antlr4ng-cli@1.0.7)
+        specifier: 4.5.0
+        version: 4.5.0(antlr4ng-cli@1.0.7)
     devDependencies:
       '@commitlint/cli':
         specifier: ^17.7.2
@@ -714,8 +714,8 @@ packages:
     resolution: {integrity: sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==}
     engines: {node: '>=6'}
 
-  dt-sql-parser@4.5.0-beta.1:
-    resolution: {integrity: sha512-1y7lLOF3SJJGh5LonzKwkIcWHxdWBNuhDT45rx5ZIT3KUyYkFDvRqJ/20sKeksQWs/r2/bIawW/4ICFOVluBAg==}
+  dt-sql-parser@4.5.0:
+    resolution: {integrity: sha512-x12CX4vqeJKUZzCDjVBlG2DLQZ7ORnqVYYmnOFiz1IMBCOuamjHUeU05IGiRbRO+VqQSoN5RasiFJAjqzZ1WJw==}
     engines: {node: '>=18'}
 
   eastasianwidth@0.2.0:
@@ -2729,7 +2729,7 @@ snapshots:
       find-up: 3.0.0
       minimatch: 3.1.2
 
-  dt-sql-parser@4.5.0-beta.1(antlr4ng-cli@1.0.7):
+  dt-sql-parser@4.5.0(antlr4ng-cli@1.0.7):
     dependencies:
       antlr4-c3: 3.3.7(antlr4ng-cli@1.0.7)
       antlr4ng: 2.0.11(antlr4ng-cli@1.0.7)

--- a/src/all.contributions.ts
+++ b/src/all.contributions.ts
@@ -5,3 +5,4 @@ import './languages/trino/trino.contribution';
 import './languages/mysql/mysql.contribution';
 import './languages/pgsql/pgsql.contribution';
 import './languages/impala/impala.contribution';
+import './languages/generic/generic.contribution';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -37,5 +37,6 @@ export enum LanguageIdEnum {
 	PG = 'pgsql',
 	SPARK = 'sparksql',
 	TRINO = 'trinosql',
-	IMPALA = 'impalasql'
+	IMPALA = 'impalasql',
+	GENERIC = 'genericsql'
 }

--- a/src/languages/generic/generic.contribution.ts
+++ b/src/languages/generic/generic.contribution.ts
@@ -1,0 +1,18 @@
+import { registerLanguage } from '../../_.contribution';
+import { LanguageIdEnum } from '../../common/constants';
+import { setupLanguageFeatures } from '../../setupLanguageFeatures';
+
+registerLanguage({
+	id: LanguageIdEnum.GENERIC,
+	extensions: ['.genericsql'],
+	aliases: ['GenericSQL', 'generic', 'Generic'],
+	loader: () => import('./generic')
+});
+
+setupLanguageFeatures(LanguageIdEnum.GENERIC, {
+	completionItems: true,
+	diagnostics: false,
+	references: false,
+	definitions: false,
+	hover: false
+});

--- a/src/languages/generic/generic.snippet.ts
+++ b/src/languages/generic/generic.snippet.ts
@@ -1,0 +1,76 @@
+import type { CompletionSnippetOption } from 'src/monaco.contribution';
+
+export const genericSnippets: CompletionSnippetOption[] = [
+	{
+		label: 'select',
+		prefix: 'SELECT',
+		body: ['SELECT ${2:column1}, ${3:column2} FROM ${1:table_name};\n$4']
+	},
+	{
+		label: 'select-join',
+		prefix: 'SELECT-JOIN',
+		body: [
+			'SELECT ${8:column1} FROM ${1:table_name1} ${2:t1}',
+			'${3:LEFT} JOIN ${4:table_name2} ${5:t2} ON ${2:t1}.${6:column1} = ${5:t2}.${7:column2};\n$9'
+		]
+	},
+	{
+		label: 'select-order-by',
+		prefix: 'SELECT-ORDER-BY',
+		body: [
+			'SELECT ${2:column1}, ${3:column2} FROM ${1:table_name} ORDER BY ${4:column1} ${5:desc};\n$6'
+		]
+	},
+	{
+		label: 'select-group-by',
+		prefix: 'SELECT-GROUP-BY',
+		body: ['SELECT ${2:column1}, COUNT(*) FROM ${1:table_name} GROUP BY ${2:column1};\n$3']
+	},
+	{
+		label: 'insert',
+		prefix: 'INSERT-INTO',
+		body: [
+			'INSERT INTO ${1:table_name} (${2:column1}, ${3:column2})',
+			'SELECT ${4:column1}, ${5:column2} FROM ${6:source_table};\n$7'
+		]
+	},
+	{
+		label: 'update',
+		prefix: 'UPDATE',
+		body: [
+			'UPDATE ${1:table_name}',
+			'SET ${2:column1} = ${3:value1}',
+			'WHERE ${4:column2} = ${5:value2};\n$6'
+		]
+	},
+	{
+		label: 'delete',
+		prefix: 'DELETE',
+		body: ['DELETE FROM ${1:table_name}', 'WHERE ${2:column1} = ${3:value1};\n$4']
+	},
+	{
+		label: 'create-table',
+		prefix: 'CREATE-TABLE',
+		body: [
+			'CREATE TABLE IF NOT EXISTS ${1:table_name} (',
+			'\t${2:column1} ${3:INT} PRIMARY KEY,',
+			'\t${4:column2} ${5:VARCHAR(100)} NOT NULL',
+			');\n$6'
+		]
+	},
+	{
+		label: 'alter-table-add',
+		prefix: 'ALTER-TABLE-ADD',
+		body: ['ALTER TABLE ${1:table_name} ADD COLUMN ${2:column_name} ${3:INT};\n$4']
+	},
+	{
+		label: 'alter-table-drop',
+		prefix: 'ALTER-TABLE-DROP',
+		body: ['ALTER TABLE ${1:table_name} DROP COLUMN ${2:column_name};\n$3']
+	},
+	{
+		label: 'drop-table',
+		prefix: 'DROP-TABLE',
+		body: ['DROP TABLE IF EXISTS ${1:table_name};\n$2']
+	}
+];

--- a/src/languages/generic/generic.ts
+++ b/src/languages/generic/generic.ts
@@ -1,0 +1,266 @@
+import type { languages } from '../../fillers/monaco-editor-core';
+import { TokenClassConsts } from '../../common/constants';
+
+export const conf: languages.LanguageConfiguration = {
+	comments: {
+		lineComment: '--',
+		blockComment: ['/*', '*/']
+	},
+	brackets: [
+		['{', '}'],
+		['[', ']'],
+		['(', ')']
+	],
+	autoClosingPairs: [
+		{ open: '{', close: '}' },
+		{ open: '[', close: ']' },
+		{ open: '(', close: ')' },
+		{ open: '"', close: '"' },
+		{ open: "'", close: "'" },
+		{ open: '`', close: '`' }
+	],
+	surroundingPairs: [
+		{ open: '{', close: '}' },
+		{ open: '[', close: ']' },
+		{ open: '(', close: ')' },
+		{ open: '"', close: '"' },
+		{ open: "'", close: "'" },
+		{ open: '`', close: '`' }
+	]
+};
+
+export const language = <languages.IMonarchLanguage>{
+	defaultToken: '',
+	tokenPostfix: '.sql',
+	ignoreCase: true,
+	brackets: [
+		{ open: '[', close: ']', token: TokenClassConsts.DELIMITER_SQUARE },
+		{ open: '(', close: ')', token: TokenClassConsts.DELIMITER_PAREN },
+		{ open: '{', close: '}', token: TokenClassConsts.DELIMITER_CURLY }
+	],
+	keywords: [
+		'ADD',
+		'ALL',
+		'ALTER',
+		'AND',
+		'AS',
+		'ASC',
+		'BETWEEN',
+		'BY',
+		'CASE',
+		'CAST',
+		'CHECK',
+		'COALESCE',
+		'COLUMN',
+		'CONSTRAINT',
+		'CREATE',
+		'CROSS',
+		'DEFAULT',
+		'DELETE',
+		'DESC',
+		'DISTINCT',
+		'DROP',
+		'ELSE',
+		'END',
+		'ESCAPE',
+		'EXCEPT',
+		'EXISTS',
+		'FALSE',
+		'FIRST',
+		'FOREIGN',
+		'FROM',
+		'FULL',
+		'GROUP',
+		'HAVING',
+		'IF',
+		'IN',
+		'INNER',
+		'INSERT',
+		'INTERSECT',
+		'INTO',
+		'IS',
+		'JOIN',
+		'KEY',
+		'LAST',
+		'LEFT',
+		'LIKE',
+		'LIMIT',
+		'NOT',
+		'NULL',
+		'NULLIF',
+		'NULLS',
+		'OFFSET',
+		'ON',
+		'OR',
+		'ORDER',
+		'OUTER',
+		'PRIMARY',
+		'RECURSIVE',
+		'REFERENCES',
+		'RENAME',
+		'RIGHT',
+		'SELECT',
+		'SET',
+		'TABLE',
+		'THEN',
+		'TO',
+		'TRUE',
+		'UNION',
+		'UNIQUE',
+		'UPDATE',
+		'VALUES',
+		'WHEN',
+		'WHERE',
+		'WITH'
+	],
+	operators: [
+		'AND',
+		'BETWEEN',
+		'IN',
+		'LIKE',
+		'NOT',
+		'EXISTS',
+		'OR',
+		'IS',
+		'UNION',
+		'INTERSECT',
+		'EXCEPT',
+		'JOIN',
+		'CROSS',
+		'INNER',
+		'OUTER',
+		'FULL',
+		'LEFT',
+		'RIGHT'
+	],
+	builtinFunctions: [
+		'AVG',
+		'COUNT',
+		'FIRST_VALUE',
+		'LAG',
+		'LAST_VALUE',
+		'LEAD',
+		'MAX',
+		'MIN',
+		'NTH_VALUE',
+		'NTILE',
+		'PERCENT_RANK',
+		'RANK',
+		'ROW_NUMBER',
+		'SUM',
+		'STDDEV',
+		'STDDEV_POP',
+		'STDDEV_SAMP',
+		'VAR_POP',
+		'VAR_SAMP',
+		'VARIANCE'
+	],
+	builtinVariables: [
+		// Not supported
+	],
+	typeKeywords: [
+		'BOOLEAN',
+		'TINYINT',
+		'SMALLINT',
+		'INT',
+		'INTEGER',
+		'BIGINT',
+		'FLOAT',
+		'DOUBLE',
+		'DECIMAL',
+		'NUMERIC',
+		'VARCHAR',
+		'CHAR',
+		'TEXT',
+		'DATE',
+		'TIME',
+		'TIMESTAMP',
+		'BINARY',
+		'VARBINARY'
+	],
+	scopeKeywords: ['CASE', 'END', 'WHEN', 'THEN', 'ELSE'],
+	pseudoColumns: [
+		// Not supported
+	],
+	tokenizer: {
+		root: [
+			{ include: '@comments' },
+			{ include: '@whitespace' },
+			{ include: '@pseudoColumns' },
+			{ include: '@customParams' },
+			{ include: '@numbers' },
+			{ include: '@strings' },
+			{ include: '@complexIdentifiers' },
+			{ include: '@scopes' },
+			[/[:;,.]/, TokenClassConsts.DELIMITER],
+			[/[\(\)\[\]\{\}]/, '@brackets'],
+			[
+				/[\w@]+/,
+				{
+					cases: {
+						'@scopeKeywords': TokenClassConsts.KEYWORD_SCOPE,
+						'@operators': TokenClassConsts.OPERATOR_KEYWORD,
+						'@typeKeywords': TokenClassConsts.TYPE,
+						'@builtinVariables': TokenClassConsts.VARIABLE,
+						'@builtinFunctions': TokenClassConsts.PREDEFINED,
+						'@keywords': TokenClassConsts.KEYWORD,
+						'@default': TokenClassConsts.IDENTIFIER
+					}
+				}
+			],
+			[/[<>=!%&+\-*/|~^]/, TokenClassConsts.OPERATOR_SYMBOL]
+		],
+		whitespace: [[/[\s\t\r\n]+/, TokenClassConsts.WHITE]],
+		comments: [
+			[/--+.*/, TokenClassConsts.COMMENT],
+			[/\/\*/, { token: TokenClassConsts.COMMENT_QUOTE, next: '@comment' }]
+		],
+		comment: [
+			[/[^*/]+/, TokenClassConsts.COMMENT],
+			[/\*\//, { token: TokenClassConsts.COMMENT_QUOTE, next: '@pop' }],
+			[/./, TokenClassConsts.COMMENT]
+		],
+		pseudoColumns: [
+			[
+				/[$][A-Za-z_][\w@#$]*/,
+				{
+					cases: {
+						'@pseudoColumns': TokenClassConsts.PREDEFINED,
+						'@default': TokenClassConsts.IDENTIFIER
+					}
+				}
+			]
+		],
+		customParams: [
+			[/\${[A-Za-z0-9._-]*}/, TokenClassConsts.VARIABLE],
+			[/\@\@{[A-Za-z0-9._-]*}/, TokenClassConsts.VARIABLE]
+		],
+		numbers: [
+			[/[$][+-]*\d*(\.\d*)?/, TokenClassConsts.NUMBER],
+			[/((\d+(\.\d*)?)|(\.\d+))([eE][\-+]?\d+)?/, TokenClassConsts.NUMBER]
+		],
+		strings: [[/'/, { token: TokenClassConsts.STRING, next: '@string' }]],
+		string: [
+			[/[^']+/, TokenClassConsts.STRING_ESCAPE],
+			[/''/, TokenClassConsts.STRING],
+			[/'/, { token: TokenClassConsts.STRING, next: '@pop' }]
+		],
+		complexIdentifiers: [
+			[/`/, { token: TokenClassConsts.IDENTIFIER_QUOTE, next: '@quotedIdentifier' }],
+			[/"/, { token: TokenClassConsts.IDENTIFIER_QUOTE, next: '@doubleQuotedIdentifier' }]
+		],
+		quotedIdentifier: [
+			[/[^`]+/, TokenClassConsts.IDENTIFIER_QUOTE],
+			[/``/, TokenClassConsts.IDENTIFIER_QUOTE],
+			[/`/, { token: TokenClassConsts.IDENTIFIER_QUOTE, next: '@pop' }]
+		],
+		doubleQuotedIdentifier: [
+			[/[^"]+/, TokenClassConsts.IDENTIFIER_QUOTE],
+			[/""/, TokenClassConsts.IDENTIFIER_QUOTE],
+			[/"/, { token: TokenClassConsts.IDENTIFIER_QUOTE, next: '@pop' }]
+		],
+		scopes: [
+			// Not supported
+		]
+	}
+};

--- a/src/languages/generic/generic.worker.ts
+++ b/src/languages/generic/generic.worker.ts
@@ -1,0 +1,11 @@
+import { worker } from '../../fillers/monaco-editor-core';
+import * as EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js';
+import { ICreateData } from '../../baseSQLWorker';
+import { GenericSQLWorker } from './genericWorker';
+
+self.onmessage = () => {
+	// ignore the first message
+	EditorWorker.initialize((ctx: worker.IWorkerContext, createData: ICreateData) => {
+		return new GenericSQLWorker(ctx, createData);
+	});
+};

--- a/src/languages/generic/genericWorker.ts
+++ b/src/languages/generic/genericWorker.ts
@@ -1,0 +1,17 @@
+import { worker } from '../../fillers/monaco-editor-core';
+import { GenericSQL } from 'dt-sql-parser/dist/parser/generic';
+import { BaseSQLWorker, ICreateData } from '../../baseSQLWorker';
+
+export class GenericSQLWorker extends BaseSQLWorker {
+	protected _ctx: worker.IWorkerContext;
+	protected parser: GenericSQL;
+	constructor(ctx: worker.IWorkerContext, createData: ICreateData) {
+		super(ctx, createData);
+		this._ctx = ctx;
+		this.parser = new GenericSQL();
+	}
+}
+
+export function create(ctx: worker.IWorkerContext, createData: ICreateData): GenericSQLWorker {
+	return new GenericSQLWorker(ctx, createData);
+}

--- a/src/setupLanguageFeatures.ts
+++ b/src/setupLanguageFeatures.ts
@@ -109,6 +109,8 @@ function getDefaultSnippets(languageId: LanguageIdEnum) {
 			return snippets.sparkSnippets;
 		case LanguageIdEnum.TRINO:
 			return snippets.trinoSnippets;
+		case LanguageIdEnum.GENERIC:
+			return snippets.genericSnippets;
 		default:
 			return [];
 	}

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -5,3 +5,4 @@ export { pgsqlSnippets } from './languages/pgsql/pgsql.snippet';
 export { sparkSnippets } from './languages/spark/spark.snippet';
 export { mysqlSnippets } from './languages/mysql/mysql.snippet';
 export { impalaSnippets } from './languages/impala/impala.snippet';
+export { genericSnippets } from './languages/generic/generic.snippet';

--- a/website/src/consts/index.ts
+++ b/website/src/consts/index.ts
@@ -38,7 +38,8 @@ export const SQL_LANGUAGES = [
 	'MySQL',
 	'PGSQL',
 	'TrinoSQL',
-	'ImpalaSQL'
+	'ImpalaSQL',
+	'GenericSQL'
 ];
 
 export const defaultLanguage = SQL_LANGUAGES[0];

--- a/website/src/languages/index.ts
+++ b/website/src/languages/index.ts
@@ -137,3 +137,15 @@ setupLanguageFeatures(LanguageIdEnum.IMPALA, {
 	hover: true,
 	preprocessCode
 });
+
+setupLanguageFeatures(LanguageIdEnum.GENERIC, {
+	completionItems: {
+		enable: true,
+		completionService
+	},
+	diagnostics: false,
+	references: true,
+	definitions: true,
+	hover: true,
+	preprocessCode
+});

--- a/website/src/languages/languageWorker.ts
+++ b/website/src/languages/languageWorker.ts
@@ -9,6 +9,7 @@ import PGSQLWorker from 'monaco-sql-languages/esm/languages/pgsql/pgsql.worker?w
 import MySQLWorker from 'monaco-sql-languages/esm/languages/mysql/mysql.worker?worker';
 import TrinoSQLWorker from 'monaco-sql-languages/esm/languages/trino/trino.worker?worker';
 import ImpalaSQLWorker from 'monaco-sql-languages/esm/languages/impala/impala.worker?worker';
+import GenericSQLWorker from 'monaco-sql-languages/esm/languages/generic/generic.worker?worker';
 
 (globalThis as any).MonacoEnvironment = {
 	getWorker(_: any, label: string) {
@@ -32,6 +33,9 @@ import ImpalaSQLWorker from 'monaco-sql-languages/esm/languages/impala/impala.wo
 		}
 		if (label === LanguageIdEnum.IMPALA) {
 			return new ImpalaSQLWorker();
+		}
+		if (label === LanguageIdEnum.GENERIC) {
+			return new GenericSQLWorker();
 		}
 		return new EditorWorker();
 	}


### PR DESCRIPTION
### 背景
dt-sql-parser 新增了 GenericSQL 通用 SQL 方言（基于 Trino 语法裁剪，只保留核心 DML/DDL 语法），本 PR 在 monaco-sql-languages 中接入 GenericSQL 的编辑器支持。

### 实现内容
- 注册 GenericSQL 语言（ID: `genericsql`，文件扩展名: `.genericsql`）
- 添加 Monarch 语法高亮定义（约 65 个核心关键字、18 种标准数据类型、20 个常用内置函数）
- 添加 11 个内置 SQL 代码片段（SELECT、INSERT、UPDATE、DELETE、CREATE TABLE 等）
- Web Worker 封装，对接 dt-sql-parser 的 `GenericSQL` 解析器
- 默认仅启用关键词高亮和代码补全，禁用语法诊断（飘红报错）、引用查找、定义跳转、悬停提示
- Website 预览页新增 GenericSQL 选项

### 功能特性
| 特性 | 状态 |
|------|------|
| 关键词高亮 | ✅ 启用 |
| 代码补全 | ✅ 启用 |
| 语法诊断 | ❌ 禁用 |
| 引用查找 | ✅ 启用 |
| 定义跳转 | ✅ 启用 |
| 悬停提示 | ✅ 启用 |

引用查找、定义跳转、悬停提示在预览地址已打开，默认未启用

### 关联
- dt-sql-parser PR：https://github.com/DTStack/dt-sql-parser/pull/469
- 预览地址：https://liuxy0551.github.io/monaco-sql-languages
