### PR TITLE
chore: upgrade monaco-editor@0.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "monaco-sql-languages",
-	"version": "1.1.0",
+	"version": "1.2.0-beta.0",
 	"description": "SQL languages for the Monaco Editor, based on monaco-languages.",
 	"scripts": {
 		"prepublishOnly": "npm run build",
@@ -56,7 +56,7 @@
 		"inquirer": "^8.2.2",
 		"jsdom": "^16.4.0",
 		"mocha": "^11.7.4",
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"prettier": "^3.3.3",
 		"pretty-quick": "^4.0.0",
 		"requirejs": "^2.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^11.7.4
         version: 11.7.4
       monaco-editor:
-        specifier: 0.52.2
-        version: 0.52.2
+        specifier: 0.54.0
+        version: 0.54.0
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -706,6 +706,9 @@ packages:
     engines: {node: '>=8'}
     deprecated: Use your platform's native DOMException instead
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -1242,6 +1245,11 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
     engines: {node: '>=10'}
@@ -1306,8 +1314,8 @@ packages:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
 
-  monaco-editor@0.52.2:
-    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2084,7 +2092,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.5.4)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.5.4))(typescript@5.5.4)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.5.4))(typescript@5.5.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -2601,7 +2609,7 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.5.4))(typescript@5.5.4):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.5.4)
@@ -2719,6 +2727,8 @@ snapshots:
   domexception@2.0.1:
     dependencies:
       webidl-conversions: 5.0.0
+
+  dompurify@3.1.7: {}
 
   dot-prop@5.3.0:
     dependencies:
@@ -3288,6 +3298,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  marked@14.0.0: {}
+
   meow@8.1.2:
     dependencies:
       '@types/minimist': 1.2.5
@@ -3369,7 +3381,10 @@ snapshots:
 
   modify-values@1.0.1: {}
 
-  monaco-editor@0.52.2: {}
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
   mri@1.2.0: {}
 

--- a/samples/esm-monaco-webpack-plugin/package.json
+++ b/samples/esm-monaco-webpack-plugin/package.json
@@ -23,7 +23,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"dependencies": {
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"monaco-editor-webpack-plugin": "7.0.1",
 		"monaco-sql-languages": "1.0.0-beta.5"
 	}

--- a/samples/esm-monaco-webpack-plugin/pnpm-lock.yaml
+++ b/samples/esm-monaco-webpack-plugin/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       monaco-editor:
-        specifier: 0.52.2
-        version: 0.52.2
+        specifier: 0.54.0
+        version: 0.54.0
       monaco-editor-webpack-plugin:
         specifier: 7.0.1
-        version: 7.0.1(monaco-editor@0.52.2)(webpack@5.101.3(webpack-cli@5.1.4))
+        version: 7.0.1(monaco-editor@0.54.0)(webpack@5.101.3(webpack-cli@5.1.4))
       monaco-sql-languages:
         specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2)
+        version: 1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0)
     devDependencies:
       css-loader:
         specifier: ^6.8.1
@@ -544,6 +544,9 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
 
@@ -1048,6 +1051,11 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1121,8 +1129,8 @@ packages:
       monaco-editor: '>= 0.31.0'
       webpack: ^4.5.0 || 5.x
 
-  monaco-editor@0.52.2:
-    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   monaco-sql-languages@1.0.0-beta.5:
     resolution: {integrity: sha512-VEjQ3qp8lch/yz6N50Qd71JBKLAsI4a258J8CIwNvUKQ2d3g7UqLFN+SoG5eQgNcz4soQDiLWorUjw5deEpTgQ==}
@@ -2282,6 +2290,8 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.1.7: {}
+
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
@@ -2793,6 +2803,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   math-random@1.0.4: {}
@@ -2865,18 +2877,21 @@ snapshots:
 
   monaco-editor-core@0.52.2: {}
 
-  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.52.2)(webpack@5.101.3(webpack-cli@5.1.4)):
+  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.54.0)(webpack@5.101.3(webpack-cli@5.1.4)):
     dependencies:
       loader-utils: 2.0.4
-      monaco-editor: 0.52.2
+      monaco-editor: 0.54.0
       webpack: 5.101.3(webpack-cli@5.1.4)
 
-  monaco-editor@0.52.2: {}
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
-  monaco-sql-languages@1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2):
+  monaco-sql-languages@1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0):
     dependencies:
       dt-sql-parser: 4.3.1(antlr4ng-cli@1.0.7)
-      monaco-editor: 0.52.2
+      monaco-editor: 0.54.0
       monaco-editor-core: 0.52.2
     transitivePeerDependencies:
       - antlr4ng-cli

--- a/samples/esm-plain-webpack/package.json
+++ b/samples/esm-plain-webpack/package.json
@@ -23,7 +23,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"dependencies": {
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"monaco-sql-languages": "1.0.0-beta.5"
 	}
 }

--- a/samples/esm-plain-webpack/pnpm-lock.yaml
+++ b/samples/esm-plain-webpack/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       monaco-editor:
-        specifier: 0.52.2
-        version: 0.52.2
+        specifier: 0.54.0
+        version: 0.54.0
       monaco-sql-languages:
         specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2)
+        version: 1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0)
     devDependencies:
       css-loader:
         specifier: ^6.8.1
@@ -538,6 +538,9 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
 
@@ -1029,6 +1032,11 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1096,8 +1104,8 @@ packages:
   monaco-editor-core@0.52.2:
     resolution: {integrity: sha512-5TOyTUymNx7jB24TGP4Qs5UEVrntDKSMzDUvW3ADaI1CFRO1t7FPhbT2u4m3iIKZf85zTM+mkCxiUSgj+v/YtA==}
 
-  monaco-editor@0.52.2:
-    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   monaco-sql-languages@1.0.0-beta.5:
     resolution: {integrity: sha512-VEjQ3qp8lch/yz6N50Qd71JBKLAsI4a258J8CIwNvUKQ2d3g7UqLFN+SoG5eQgNcz4soQDiLWorUjw5deEpTgQ==}
@@ -2255,6 +2263,8 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.1.7: {}
+
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
@@ -2756,6 +2766,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   math-random@1.0.4: {}
@@ -2828,12 +2840,15 @@ snapshots:
 
   monaco-editor-core@0.52.2: {}
 
-  monaco-editor@0.52.2: {}
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
-  monaco-sql-languages@1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2):
+  monaco-sql-languages@1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0):
     dependencies:
       dt-sql-parser: 4.3.1(antlr4ng-cli@1.0.7)
-      monaco-editor: 0.52.2
+      monaco-editor: 0.54.0
       monaco-editor-core: 0.52.2
     transitivePeerDependencies:
       - antlr4ng-cli

--- a/samples/esm-vite-monaco-editor-react/package-lock.json
+++ b/samples/esm-vite-monaco-editor-react/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@monaco-editor/react": "^4.7.0",
-				"monaco-editor": "0.52.2",
+				"monaco-editor": "0.54.0",
 				"monaco-sql-languages": "1.0.0-beta.5",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0"
@@ -1188,6 +1188,12 @@
 				}
 			}
 		},
+		"node_modules/dompurify": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.1.7.tgz",
+			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)"
+		},
 		"node_modules/dt-sql-parser": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmmirror.com/dt-sql-parser/-/dt-sql-parser-4.3.1.tgz",
@@ -1351,10 +1357,27 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/marked": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmmirror.com/marked/-/marked-14.0.0.tgz",
+			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/monaco-editor": {
-			"version": "0.52.2",
-			"resolved": "https://registry.npmmirror.com/monaco-editor/-/monaco-editor-0.52.2.tgz",
-			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
+			"version": "0.54.0",
+			"resolved": "https://registry.npmmirror.com/monaco-editor/-/monaco-editor-0.54.0.tgz",
+			"integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+			"license": "MIT",
+			"dependencies": {
+				"dompurify": "3.1.7",
+				"marked": "14.0.0"
+			}
 		},
 		"node_modules/monaco-editor-core": {
 			"version": "0.52.2",
@@ -2373,6 +2396,11 @@
 				"ms": "2.1.2"
 			}
 		},
+		"dompurify": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.1.7.tgz",
+			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
+		},
 		"dt-sql-parser": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmmirror.com/dt-sql-parser/-/dt-sql-parser-4.3.1.tgz",
@@ -2489,10 +2517,19 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"marked": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmmirror.com/marked/-/marked-14.0.0.tgz",
+			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="
+		},
 		"monaco-editor": {
-			"version": "0.52.2",
-			"resolved": "https://registry.npmmirror.com/monaco-editor/-/monaco-editor-0.52.2.tgz",
-			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
+			"version": "0.54.0",
+			"resolved": "https://registry.npmmirror.com/monaco-editor/-/monaco-editor-0.54.0.tgz",
+			"integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+			"requires": {
+				"dompurify": "3.1.7",
+				"marked": "14.0.0"
+			}
 		},
 		"monaco-editor-core": {
 			"version": "0.52.2",

--- a/samples/esm-vite-monaco-editor-react/package.json
+++ b/samples/esm-vite-monaco-editor-react/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"@monaco-editor/react": "^4.7.0",
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"monaco-sql-languages": "1.0.0-beta.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"

--- a/samples/esm-vite/package.json
+++ b/samples/esm-vite/package.json
@@ -9,7 +9,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"monaco-sql-languages": "1.0.0-beta.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"

--- a/samples/esm-vite/pnpm-lock.yaml
+++ b/samples/esm-vite/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       monaco-editor:
-        specifier: 0.52.2
-        version: 0.52.2
+        specifier: 0.54.0
+        version: 0.54.0
       monaco-sql-languages:
-        specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2)
+        specifier: 1.0.0-beta.5
+        version: 1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -316,56 +316,67 @@ packages:
     resolution: {integrity: sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.2':
     resolution: {integrity: sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.2':
     resolution: {integrity: sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.2':
     resolution: {integrity: sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.2':
     resolution: {integrity: sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.2':
     resolution: {integrity: sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.2':
     resolution: {integrity: sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.2':
     resolution: {integrity: sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.2':
     resolution: {integrity: sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.2':
     resolution: {integrity: sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.2':
     resolution: {integrity: sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.2':
     resolution: {integrity: sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==}
@@ -467,6 +478,9 @@ packages:
       supports-color:
         optional: true
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   dt-sql-parser@4.3.1:
     resolution: {integrity: sha512-WlFB9of+ChwWtc5M222jHGIpzqHx51szLe/11GAwwbA+4hRaVkMpWMf2bbYj4i855edSoTQ52zyLJVOpe+4OVg==}
     engines: {node: '>=18'}
@@ -512,11 +526,19 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  monaco-editor@0.52.2:
-    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
-  monaco-sql-languages@1.0.0-beta.3:
-    resolution: {integrity: sha512-lmSFrgr3cvtbkUFZmiXC5OqJZ0GM6vXzRFnNSd8OoGNX/MenYypkH9FdJ/2SJhHzKIKRm4KCiGPK7r+VNHCk5A==}
+  monaco-editor-core@0.52.2:
+    resolution: {integrity: sha512-5TOyTUymNx7jB24TGP4Qs5UEVrntDKSMzDUvW3ADaI1CFRO1t7FPhbT2u4m3iIKZf85zTM+mkCxiUSgj+v/YtA==}
+
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
+
+  monaco-sql-languages@1.0.0-beta.5:
+    resolution: {integrity: sha512-VEjQ3qp8lch/yz6N50Qd71JBKLAsI4a258J8CIwNvUKQ2d3g7UqLFN+SoG5eQgNcz4soQDiLWorUjw5deEpTgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       monaco-editor: '>=0.52.2'
@@ -968,6 +990,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dompurify@3.1.7: {}
+
   dt-sql-parser@4.3.1(antlr4ng-cli@1.0.7):
     dependencies:
       antlr4-c3: 3.3.7(antlr4ng-cli@1.0.7)
@@ -1024,12 +1048,20 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  monaco-editor@0.52.2: {}
+  marked@14.0.0: {}
 
-  monaco-sql-languages@1.0.0-beta.3(antlr4ng-cli@1.0.7)(monaco-editor@0.52.2):
+  monaco-editor-core@0.52.2: {}
+
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
+
+  monaco-sql-languages@1.0.0-beta.5(antlr4ng-cli@1.0.7)(monaco-editor@0.54.0):
     dependencies:
       dt-sql-parser: 4.3.1(antlr4ng-cli@1.0.7)
-      monaco-editor: 0.52.2
+      monaco-editor: 0.54.0
+      monaco-editor-core: 0.52.2
     transitivePeerDependencies:
       - antlr4ng-cli
 

--- a/src/fillers/monaco-editor-core-amd.ts
+++ b/src/fillers/monaco-editor-core-amd.ts
@@ -4,9 +4,34 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Resolves with the global monaco API
+// Uses a proxy to lazily access self.monaco, which may not be available at load time
 
 declare const define: any;
 
 define([], function () {
-	return (<any>self).monaco;
+	// Return a proxy that lazily resolves self.monaco
+	// This handles the case where self.monaco is not yet available when this module loads
+	return new Proxy(
+		{},
+		{
+			get: function (_target: any, prop: string) {
+				// Try multiple global references to find monaco
+				const g =
+					typeof globalThis !== 'undefined'
+						? globalThis
+						: typeof self !== 'undefined'
+							? self
+							: typeof global !== 'undefined'
+								? global
+								: {};
+				const monaco = (g as any).monaco;
+				if (!monaco) {
+					throw new Error(
+						'Monaco editor API not available. Ensure editor.main.js is loaded before language contributions.'
+					);
+				}
+				return monaco[prop];
+			}
+		}
+	);
 });

--- a/test/all.js
+++ b/test/all.js
@@ -3,31 +3,65 @@ const jsdom = require('jsdom');
 const glob = require('fast-glob');
 const path = require('path');
 const Mocha = require('mocha');
+const nodeCrypto = require('crypto');
 
-requirejs.config({
-	baseUrl: path.join(__dirname, '../'),
-	paths: {
-		vs: 'node_modules/monaco-editor/dev/vs',
-		'vs/css': 'test/css.mock',
-		'vs/nls': 'test/nls.mock',
-		'out/amd/fillers/monaco-editor-core': 'out/amd/fillers/monaco-editor-core-amd'
-	},
-	nodeRequire: require
-});
+// Monaco Editor 0.54.0+ requires crypto for generating unique IDs
+if (!globalThis.crypto) {
+	globalThis.crypto = {
+		randomUUID: () => nodeCrypto.randomUUID(),
+		getRandomValues: (arr) => nodeCrypto.getRandomValues(arr)
+	};
+}
+global.crypto = globalThis.crypto;
 
+// Set up DOM environment BEFORE any AMD module loading
 const tmp = new jsdom.JSDOM('<!DOCTYPE html><html><body></body></html>');
 global.AMD = true;
 global.document = tmp.window.document;
 global.navigator = tmp.window.navigator;
 global.self = global;
+global.UIEvent = tmp.window.UIEvent;
+global.Element = tmp.window.Element;
+global.CSS = {
+	supports: function () {
+		return false;
+	},
+	escape: function (value) {
+		return String(value).replace(/[^a-zA-Z0-9_\-]/g, function (ch) {
+			return '\\' + ch;
+		});
+	}
+};
 global.document.queryCommandSupported = function () {
 	return false;
 };
-global.UIEvent = tmp.window.UIEvent;
-global.define = requirejs.define;
 
-// 添加完整的DOM环境支持
-global.Element = tmp.window.Element;
+// Monaco Editor 0.54.0+ uses document.baseURI for worker URLs
+if (!document.baseURI) {
+	Object.defineProperty(document, 'baseURI', {
+		get: () => 'file://' + process.cwd() + '/',
+		configurable: true
+	});
+}
+
+// Mock URL constructor for Node.js environment
+const OriginalURL = globalThis.URL;
+class MockURL {
+	constructor(url, base) {
+		if (typeof url === 'string' && url.startsWith('/')) {
+			this.href = url;
+			return;
+		}
+		try {
+			const instance = new OriginalURL(url, base);
+			this.href = instance.href;
+		} catch {
+			this.href = url;
+		}
+	}
+}
+global.URL = MockURL;
+
 global.window = {
 	location: {},
 	navigator: tmp.window.navigator,
@@ -37,6 +71,8 @@ global.window = {
 			addEventListener: function () {}
 		};
 	},
+	addEventListener: function () {},
+	removeEventListener: function () {},
 	setInterval: setInterval,
 	clearInterval: clearInterval,
 	setTimeout: setTimeout,
@@ -48,6 +84,19 @@ if (!document.body) {
 	const body = document.createElement('body');
 	document.appendChild(body);
 }
+
+global.define = requirejs.define;
+
+requirejs.config({
+	baseUrl: path.join(__dirname, '../'),
+	paths: {
+		vs: 'node_modules/monaco-editor/dev/vs',
+		'vs/css': 'test/css.mock',
+		'vs/nls': 'test/nls.mock',
+		'out/amd/fillers/monaco-editor-core': 'out/amd/fillers/monaco-editor-core-amd'
+	},
+	nodeRequire: require
+});
 
 requirejs(
 	['./test/setup'],

--- a/test/setup.js
+++ b/test/setup.js
@@ -30,7 +30,13 @@ define('vs/nls', [], {
 });
 
 define(['vs/editor/editor.main'], function (api) {
-	global.monaco = api;
+	// Monaco Editor 0.54.0+ exports as api.m instead of api directly
+	const monaco = api.m || api;
+	global.monaco = monaco;
+	globalThis.monaco = monaco;
+	if (typeof self !== 'undefined') {
+		self.monaco = monaco;
+	}
 });
 
 // 定义Mocha全局函数

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
 		"esbuild": "^0.24.2",
 		"idb-keyval": "^6.2.1",
 		"immer": "^10.1.3",
-		"monaco-editor": "0.52.2",
+		"monaco-editor": "0.54.0",
 		"rc-tabs": "^15.5.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       monaco-editor:
-        specifier: 0.52.2
-        version: 0.52.2
+        specifier: 0.54.0
+        version: 0.54.0
       rc-tabs:
         specifier: ^15.5.1
         version: 15.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1308,6 +1308,9 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -1946,6 +1949,11 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2023,6 +2031,9 @@ packages:
 
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -4139,6 +4150,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.1.7: {}
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -4787,6 +4800,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.14: {}
@@ -4863,6 +4878,11 @@ snapshots:
   monaco-editor-nls@3.1.0: {}
 
   monaco-editor@0.52.2: {}
+
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
   ms@2.1.2: {}
 


### PR DESCRIPTION
## 简介

依赖的 monaco-editor 版本从 0.52.2 升级到 0.54.0

按 commit 查看，chore commit 中的改动原因：

---
1. src/fillers/monaco-editor-core-amd.ts

  目的：解决 Monaco 0.54.0 模块加载顺序变化导致 self.monaco 未定义的问题。

  0.52.2 时，这个文件直接返回 self.monaco，因为 Monaco 在所有语言插件加载前就已经挂载到全局。0.54.0 改变了内部模块拆分方式，语言插件可能在 Monaco 挂载到全局之前就加载了。改用 Proxy
  后，属性访问会被延迟到实际使用时才解析，避开加载顺序问题。

  ---
  2. test/setup.js

  目的：适配 Monaco 0.54.0 的导出格式变化。

  0.52.2 中 editor.main 直接导出 Monaco API 对象，0.54.0 改为通过 exports.m 导出。api.m || api 这个兼容写法确保两种格式都能正确获取到 Monaco 实例并挂载到 global.monaco。

  ---
  3. test/all.js

  目的：为 Monaco 0.54.0 新增的浏览器 API 依赖提供 Node.js 环境下的 polyfill。

  Monaco 0.54.0 内部开始使用更多浏览器原生 API，而测试运行在 Node.js 中没有这些 API，需要手动模拟：

  | API | 原因 |
  |---|---|
  | `crypto.randomUUID` / `getRandomValues` | Monaco 用它生成唯一 ID |
  | `document.baseURI` | Monaco 用它拼接 worker URL |
  | `URL` 构造函数 | Monaco 用它解析资源路径 |
  | `CSS.supports` / `CSS.escape` | 主题服务中用来处理 CSS 类名 |
  | `window.addEventListener` | `ContextKeyService` 监听 DOM 事件 |

  这些在 0.52.2 中都不需要，是 0.54.0 新引入的依赖。